### PR TITLE
Offer Python-only setup for the released dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@ For electrical/infrastructure engineers, Python developers, and educators: repla
 
 ![Actual synthetic dashboard](docs/images/overview.png)
 
-## Run
+## Try the released dashboard
+
+Use the [Python-only quickstart](docs/quickstart.md#run-the-released-dashboard-python-only) to install the [0.2.0a0 release](https://github.com/mohammadrezwankhan/datacenter-twin-lab/releases/tag/v0.2.0a0) in an isolated environment. The wheel includes the built dashboard, so this route needs Python 3.12+ with pip and a browser; Git and Node are not needed. Installation downloads the wheel and API dependencies. The installed examples run locally.
+
+The [worked tutorial](docs/tutorials/continuity-walkthrough.md) explains what to look for: one surviving path serves 665 kW of a 1,000 kW request, and the generator-failure fixture depletes its battery at 607.8 s.
+
+## Run from source
 
 Clone the repository, then run with Python 3.12+:
 
@@ -47,6 +53,8 @@ Read the [quickstart](docs/quickstart.md), [electrical boundary](docs/engineerin
 
 ## Provenance and contributions
 
-Original code, documentation, and synthetic fixtures use [Apache-2.0](LICENSE). See [NOTICE](NOTICE), [synthetic provenance](data/provenance/manifest.json), and the dated catalogue packaged in `datacenter_twin/resources/catalog.json`. No private manual, planning brief, Git history, internal campaign records, credentials, or customer traces are included in this export.
+Original code, documentation, and synthetic fixtures use [Apache-2.0](LICENSE). See [NOTICE](NOTICE), [synthetic provenance](data/provenance/manifest.json), and the dated catalogue packaged in `datacenter_twin/resources/catalog.json`. No private manual, planning brief, prior private Git history, internal campaign records, credentials, or customer traces are included in this export.
+
+[SOURCE-MANIFEST.json](SOURCE-MANIFEST.json) records the original `v0.2.0a0` release snapshot. Its hashes apply to the [tagged source](https://github.com/mohammadrezwankhan/datacenter-twin-lab/tree/v0.2.0a0), not subsequent documentation changes on `main`.
 
 Contribute a reproducible mismatch, an independently derived numerical edge case, or a primary-source correction with its date and uncertainty. Run the tests and describe assumptions and actual validation. Preserve third-party notices. See [contribution guidance](CONTRIBUTING.md) and [citation metadata](CITATION.cff). Cite the exact release or commit you use.

--- a/SOURCE-MANIFEST.json
+++ b/SOURCE-MANIFEST.json
@@ -1,6 +1,9 @@
 {
   "schema_version": 1,
-  "status": "validated_public_source",
+  "status": "validated_historical_release_snapshot",
+  "applies_to_public_revision": "42ede550e731619fefe4a4faef1ecbb6d87c304a",
+  "applies_to_release_tag": "v0.2.0a0",
+  "verification_scope": "The hashes and validation below describe the original tagged release, not later changes on main. The original manifest and release assets remain available at v0.2.0a0.",
   "source_repository": "mohammadrezwankhan/ai-datacenter-twin",
   "source_head": "426234da8686b6b142c07b4985b2353501fb2629",
   "source_method": "Allowlisted current working files, not a Git-object migration; file hashes are authoritative",

--- a/docs/contracts/local-api.md
+++ b/docs/contracts/local-api.md
@@ -1,6 +1,6 @@
 # Local API and dashboard
 
-Start with `python -m datacenter_twin serve`, after installing the optional API dependencies and building `apps/web`. The CLI binds only to `127.0.0.1:8000`; `--port` accepts 1–65535. The compiled React dashboard is served from the same process and origin. OpenAPI operation metadata is available at `/openapi.json`. The exact input and output fields are documented in [electrical-v2.md](electrical-v2.md); the domain constructors enforce constraints that OpenAPI metadata alone does not express.
+Start with `python -m datacenter_twin serve` after installing the optional API dependencies. The [released wheel](../quickstart.md#run-the-released-dashboard-python-only) includes the compiled dashboard; a source checkout requires building `apps/web` first. The CLI binds only to `127.0.0.1:8000`; `--port` accepts 1–65535. The compiled React dashboard is served from the same process and origin. OpenAPI operation metadata is available at `/openapi.json`. The exact input and output fields are documented in [electrical-v2.md](electrical-v2.md); the domain constructors enforce constraints that OpenAPI metadata alone does not express.
 
 | Method / path | Input | Result |
 | --- | --- | --- |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,48 @@
 # Quickstart
 
-Use Python 3.12 or later and open a terminal in the cloned repository root. The CLI and electrical engine use only the standard library. The optional API/dashboard setup follows below.
+Choose the released dashboard to explore the model with Python and a browser, or use the source checkout to edit code and run the full tests. Both routes require Python 3.12 or later. The CLI and electrical engine use only the standard library; the dashboard server needs the optional API dependencies.
+
+## Run the released dashboard (Python only)
+
+In an empty working folder, create an isolated environment and install the public `0.2.0a0` wheel with its `api` extra. These commands call the environment's Python directly, so no activation script is needed. The URL pins the release asset and its SHA-256 hash; it does not rely on a PyPI publication of this project.
+
+Windows / PowerShell:
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\python.exe -m pip install "datacenter-twin-lab[api] @ https://github.com/mohammadrezwankhan/datacenter-twin-lab/releases/download/v0.2.0a0/datacenter_twin_lab-0.2.0a0-py3-none-any.whl#sha256=0a6c56ce5fe5fd25d9886d35112eea56408450c8b7181e62b698b3c58a901261"
+.\.venv\Scripts\python.exe -m datacenter_twin serve
+```
+
+macOS / Linux:
+
+```sh
+python3 -m venv .venv
+.venv/bin/python -m pip install "datacenter-twin-lab[api] @ https://github.com/mohammadrezwankhan/datacenter-twin-lab/releases/download/v0.2.0a0/datacenter_twin_lab-0.2.0a0-py3-none-any.whl#sha256=0a6c56ce5fe5fd25d9886d35112eea56408450c8b7181e62b698b3c58a901261"
+.venv/bin/python -m datacenter_twin serve
+```
+
+Use a Python executable at version 3.12 or later; for example, replace the first Windows `python` with `py -3.12` if you use that launcher. Your Python installation must include pip and venv support. The initial installation needs network access to GitHub and the dependency package index. It installs the built interface and API dependencies; Git, Node, an API key and a cloud account are not required. The release pins FastAPI and Uvicorn; this convenient extra resolves their compatible transitive dependencies. Use the locked source workflow below when you need the repository's exact development dependency set.
+
+Open [127.0.0.1:8000](http://127.0.0.1:8000). Select **Generator failure / battery depletion**, run the scenario, and select the `607.8 s` battery-depleted event. Served IT power drops to zero until restoration at `900 s`. The source is synthetic and the tariff is fictional. Try **A-path maintenance / surviving overload** to see 665 kW served and 335 kW unserved during the outage interval. [The tutorial](tutorials/continuity-walkthrough.md) derives both results.
+
+Stop the server with Ctrl+C. If port 8000 is occupied, append `--port 8001` to the serve command and open port 8001. After stopping, you can run the bundled CLI preset in the same environment:
+
+```powershell
+# Windows / PowerShell
+.\.venv\Scripts\python.exe -m datacenter_twin simulate --preset generator_failure
+```
+
+```sh
+# macOS / Linux
+.venv/bin/python -m datacenter_twin simulate --preset generator_failure
+```
+
+The presets and catalogue ship in the wheel. Source-only files such as `data/scenarios/baseline-1mw.json` and the test suite require the checkout below. Avoid running the installed dashboard from inside an unbuilt source checkout, where Python can import that checkout instead of the installed package. The server binds to loopback; this is a local research tool with no physical controls or calibrated facility claims.
+
+## Run from source
+
+Clone the [public repository](https://github.com/mohammadrezwankhan/datacenter-twin-lab), then open a terminal in its root:
 
 ```sh
 python -m datacenter_twin --version


### PR DESCRIPTION
The README currently sends dashboard users through Git and a Node build, although the released wheel already contains the compiled interface. Add a Python-only installation route with isolated environments, exact release URL and SHA-256, platform-specific commands, and hand-checkable results. Keep the source workflow for development, explain which example files are checkout-only, and distinguish the release's transitive dependency resolution from the locked development environment.

The existing source manifest is explicitly scoped to the original `v0.2.0a0` snapshot so documentation changes on `main` do not imply that the published wheel or historical hashes changed. No runtime or release asset changes.

Validation: downloaded and installed the hash-pinned public wheel with its API extra into a fresh Windows/Python 3.12.14 environment outside the source checkout, without Git or Node commands. `pip check`, installed CLI and HTTP checks passed for health, dashboard HTML/JS/CSS, notices, presets, demo and catalogue. Both presets completed through the installed HTTP API and matched the 607.8 s battery boundary and 665/335 kW path result. Servers were stopped after verification. The public suite ran 89 tests: 88 passed and one Windows symlink-privilege skip. A separate read-only package audit confirmed the wheel resources/extras and source-only limitations. macOS commands are provided but were not executed locally; CI covers Linux and Windows.

This addresses a directly observed setup requirement; there is no measured audience-conversion result yet.
