### PR TITLE
Launch 12 power lessons and a fast 50 MW browser experiment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,7 +71,7 @@ jobs:
           retention-days: 14
 
   browser-demo:
-    name: Browser Python demo
+    name: Browser demo and Python parity
     needs: verify
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -87,6 +87,7 @@ jobs:
           cache-dependency-path: apps/web/package-lock.json
       - run: npm --prefix apps/web ci --ignore-scripts
       - run: python scripts/prepare_browser_demo.py
+      - run: npm --prefix apps/web run test:engine
       - run: npm --prefix apps/web run build:demo
       - name: Install browser
         run: npx playwright install --with-deps chromium

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,21 @@
 # Contributing
 
-Datacenter Twin Lab is a deterministic, local-first simulator for synthetic electrical-continuity what-if scenarios. Contributions should make a bounded behavior easier to reproduce, inspect, teach, or review.
+Datacenter Twin Lab helps datacenter engineers learn power continuity through deterministic, synthetic aggregate-load scenarios. Contributions should make a first run easier to follow, a result easier to inspect, or a bounded behavior easier to reproduce and review.
 
 ## Good first contributions
 
-- Report a reproducible mismatch with the exact preset or sanitized scenario, revision, command, units, expected result, and observed result.
-- Add an independently derived numerical edge case with a test and a short explanation of the equation.
-- Improve a scenario page, glossary, diagram, or first-run instruction without changing model semantics.
+You can help without deriving a new electrical edge case:
+
+- Fix unclear wording, a broken link, a misleading label, or a step that no longer matches the browser journey.
+- Follow the [first-run quickstart](docs/quickstart.md), then report one confusing step with the page, control, expected wording, and observed wording.
+- Check keyboard navigation, focus order, contrast, readable units, and event-table labels in the browser demo; record the browser and a reproducible observation.
+- Make a small implementation change with a focused test and explain the user-visible result.
+- Improve a scenario page, glossary entry, diagram, or first-run instruction without changing model semantics.
 - Correct a dated primary-source citation while preserving the source date, identifier, and uncertainty.
 
-Browse the [scenario catalog](docs/scenarios/index.md) and [beginner contribution ideas](docs/scenarios/contribution-ideas.md) before opening a feature proposal. Keep a proposed change to one bounded subsystem and explain the user outcome in the issue or pull request.
+Browse the [scenario catalog](docs/scenarios/index.md), [beginner contribution ideas](docs/scenarios/contribution-ideas.md), and [course notes](docs/tutorials/power-systems-course.md) before opening a feature proposal. Keep a proposed change to one bounded subsystem and explain the user outcome in the issue or pull request.
+
+Numerical review is welcome when you can state the independent equation, units, and expected result. It is an optional deeper path for numerical bugs and new scenario behavior; a text, link, keyboard, or readability contribution can use the focused checks below.
 
 ## Before opening a pull request
 
@@ -20,13 +26,13 @@ python -m unittest discover -s tests -v
 npm --prefix apps/web run build
 ```
 
-For a numerical or scenario change, also run the affected preset and record the command, input hash, expected values, observed values, units, and whether the result is synthetic. A changed snapshot alone is not an independent derivation. Keep unknown costs and unavailable values explicit.
+For a documentation-only change, check relative links, code blocks, Mermaid fences, and caveat wording. Follow the first-run browser route when the copy describes a control. Do not include generated output files, private manuals, licensed standards text, credentials, customer traces, or internal planning/history.
 
-For a documentation-only change, check links, code blocks, Mermaid fences, and caveat wording. Do not include generated output files, private manuals, licensed standards text, credentials, customer traces, or internal planning/history.
+For a numerical or scenario change, also run the affected preset and record the command, input hash, expected values, observed values, units, and whether the result is synthetic. A changed snapshot alone is not an independent derivation. Keep unknown costs and unavailable values explicit.
 
 ## Model and scope rules
 
-The current model covers one synthetic IT load, topology, finite stored energy, generator delay/failure, conversion losses, path limits, shared-domain events, and deterministic replay. It does not establish facility calibration, protection coordination, AC transients, cooling behavior, workload throughput, certification, uptime, or physical safety. Do not add physical-control instructions or imply that a test is an equipment validation.
+The current model covers one synthetic aggregate IT load, topology, finite stored energy, generator delay/failure, conversion losses, path limits, shared-domain events, and deterministic replay. The browser AI-cluster teaching case scales the synthetic demand to 50,000 kW and initial battery energy to 5,000 kWh while preserving the fixture ratios. It does not establish facility calibration, protection coordination, AC transients, cooling behavior, workload throughput, certification, uptime, grid adequacy, GPU performance, or physical safety. Do not add physical-control instructions or imply that a test is an equipment validation.
 
 New calculations need explicit units, deterministic behavior or a documented source of nondeterminism, provenance for third-party data, and at least one independently stated expected result. Keep schema-1 planning/PUE inputs separate from schema-2 electrical topology; neither model may silently infer the other.
 
@@ -34,4 +40,14 @@ New calculations need explicit units, deterministic behavior or a documented sou
 
 Use the pull-request template. Describe the user-visible result, files changed, checks run, assumptions, and any open limitation. Small focused changes are easier to verify. Preserve third-party notices and Apache-2.0 licensing terms.
 
-For confidential security concerns, follow [SECURITY.md](SECURITY.md). Do not put credentials, private source material, or customer data in a public issue or pull request. For normal questions and reproducibility help, use [GitHub Discussions](https://github.com/mohammadrezwankhan/datacenter-twin-lab/discussions) when enabled or open a focused issue.
+For confidential security concerns, follow [SECURITY.md](SECURITY.md). Do not put credentials, private source material, or customer data in a public issue or pull request. For normal questions and reproducibility help, use [GitHub Discussions](https://github.com/mohammadrezwankhan/datacenter-twin-lab/discussions) or open a focused issue.
+
+## Assumptions and limits
+
+The synthetic 1 MW fixture uses 1,000 kW IT demand, 1,800 s duration, 0.95 distribution efficiency, 100 kWh initial and maximum battery energy, 0.90 discharge efficiency, 700 kW path capacities, a 30 s generator start delay, and a fictional USD 0.10/kWh tariff. The 50 MW AI-cluster teaching case uses 50,000 kW and 5,000 kWh with the same ratios. These values are assumptions, not selected equipment ratings, live prices, a benchmark, a certification, legal-compliance evidence, or a real-site calibration.
+
+The model excludes cooling transients, workload queues and throughput, battery aging, temperature, generator ramp/cooldown/fuel dynamics, transfer and switching transients, AC load flow, impedance-based load sharing, protection coordination, harmonics, short-circuit and arc-flash studies, reliability probabilities, Tier claims, service-level claims, physical controls, and facility safety assessment. Unknown costs, unavailable quantities, and missing data must remain explicit.
+
+The browser demo has no shared simulation backend or client analytics. The API binds to loopback. No shared service, database, login, tenant isolation, persistent audit, facility telemetry, FAT/SAT, independent external review, formal security audit, or calibration dataset is supplied by this release. The browser's exact JavaScript default and optional on-demand Python verification are software behaviors to be checked by the current release evidence; neither establishes physical accuracy. Review the [reproducibility capsule](docs/validation/reproducibility-capsule.md) and [review protocol](docs/validation/review-protocol.md) before making a numerical claim.
+
+The public source tree excludes private manuals, planning references and the private repository history. Original code and synthetic fixtures use [Apache-2.0](LICENSE); preserve [NOTICE](NOTICE) and the [browser runtime licenses](docs/third-party/README.md).

--- a/README.md
+++ b/README.md
@@ -1,42 +1,47 @@
 # Datacenter Twin Lab
 
-**Replay a power failure, change the battery reserve, and explain the result.**
+**How long can a 5 MWh battery keep a 50 MW aggregate AI-cluster load supplied when utility and generator power fail?**
 
-A reproducible, local-first power-continuity what-if simulator for engineers, researchers, Python developers, and educators.
+The browser demo's synthetic AI-cluster case requests **50,000 kW (50 MW)** and starts with **5,000 kWh (5 MWh)** of stored battery energy. When utility and generator supply fail at 300 s, the battery supplies IT for **307.8 s** and depletes at **607.8 s elapsed**. That gives a datacenter engineer a concrete continuity question to run, inspect, and reproduce.
 
-[**Open the zero-install demo →**](https://mohammadrezwankhan.github.io/datacenter-twin-lab/) · [Tutorials](docs/tutorials/index.md) · [Scenario catalog](docs/scenarios/index.md) · [Quickstart](docs/quickstart.md) · [Discuss a result](https://github.com/mohammadrezwankhan/datacenter-twin-lab/discussions)
+[**Open the browser demo and run the AI-cluster scenario →**](https://mohammadrezwankhan.github.io/datacenter-twin-lab/) · [Start the 12-lesson course](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=power-energy) · [Course notes](docs/tutorials/power-systems-course.md)
 
-[![Actual browser demo: change battery reserve, replay depletion and recovery, compare reserves, and export a report](docs/images/demo-walkthrough.gif)](https://mohammadrezwankhan.github.io/datacenter-twin-lab/)
+After the result appears, continue with the [tutorials](docs/tutorials/index.md), [scenario catalog](docs/scenarios/index.md), or [quickstart](docs/quickstart.md). Use [Discussions](https://github.com/mohammadrezwankhan/datacenter-twin-lab/discussions) to share a reproducible result.
 
-21-second step recording of the actual Python browser demo. [Still image](docs/images/demo-preview.png) · [Transcript and capture recipe](docs/examples/demo-walkthrough.md). Waiting and pointer movement are omitted; this is not a speed benchmark.
+## Try the result now
 
-![Datacenter Twin Lab visual concept for the champion roadmap](docs/images/datacenter-twin-lab-cover-v1.png)
+1. Open the [zero-install browser demo](https://mohammadrezwankhan.github.io/datacenter-twin-lab/).
+2. Run **AI-cluster generator failure** with the default synthetic fixture.
+3. Select the **Battery depleted 607.8 s** event. Served IT power is **0 kW** until utility restoration at **900 s**.
 
-Alpha 0.3.0a0 · Python 3.12+ · Apache-2.0
+The AI-cluster values are a 50× scale-up of the verified 1 MW / 100 kWh teaching fixture. The ratios preserve the same modeled 0.90 discharge efficiency and 0.95 distribution efficiency, so the ride-through duration and event times stay the same.
 
-[![Tests](https://github.com/mohammadrezwankhan/datacenter-twin-lab/actions/workflows/tests.yml/badge.svg)](https://github.com/mohammadrezwankhan/datacenter-twin-lab/actions/workflows/tests.yml)
+The default browser journey calculates locally with exact JavaScript arithmetic. Use **Verify against Python** for an optional Pyodide cross-check; the Python runtime is loaded on demand for that check rather than for the initial result.
 
-## A generator fails. How long does the battery last?
+No installation or account is needed for the browser result. See [calculation and privacy](docs/engineering/browser-demo.md) for the browser boundary and the [teaching notebook](docs/examples/battery-ride-through.ipynb) for an independently calculated reference case.
 
-Start with a synthetic 1 MW load and 100 kWh battery. Utility and generator fail at 300 seconds. The battery supplies IT for **307.8 seconds**, depletes at **607.8 seconds elapsed**, and utility restores service at **900 seconds**.
+## A short 1 MW experiment
 
-Try a short experiment after the [demo](https://mohammadrezwankhan.github.io/datacenter-twin-lab/) loads:
+The original `generator_failure` preset remains available for the small fixture. Open it with [`?preset=generator_failure`](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?preset=generator_failure), change **Initial battery** from **100** to **50 kWh**, run the scenario, and inspect the battery-depleted event. Pre-outage charging explains why the charging-enabled 50 kWh case lasts until **478.2675 s**. Export a report or compare reserves after the run.
 
-1. Change **Initial battery** from **100** to **50 kWh**, then select **Run scenario**.
-2. Select **Battery depleted 478.3 s**: delivered IT power is **0 kW**.
-3. Select **Utility recovers 900 s**: delivered IT power is **1,000 kW**. Export a report or compare reserves below.
+The [1 MW recorded walkthrough](docs/examples/demo-walkthrough.md) preserves an earlier interface capture, with a text transcript and reproduction recipe. The live demo above contains the current controls.
 
-The same Python engine runs on your device through WebAssembly. No installation or account is needed; the first load downloads about 14 MB. Pre-outage charging explains why the 50 kWh case lasts until 478.2675 s. [Calculation and privacy](docs/engineering/browser-demo.md) · [Teaching notebook](docs/examples/battery-ride-through.ipynb).
+## Choose a question
 
-| You can use it to | Model boundary |
-| --- | --- |
-| Compare synthetic utility, generator, battery, and path failures | Assumed equipment ratings and efficiencies; no facility calibration |
-| Reproduce event times, energy ledgers, and sensitivity reports | Electrical continuity only; no AC transients, protection, cooling, or workload prediction |
-| Learn, inspect, and share a calculation locally | No physical controls, certified uptime, or facility safety assessment |
+| Question | Preset | Expected result |
+| --- | --- | --- |
+| What happens with a 50 MW aggregate AI-cluster load? | [ai_cluster_generator_failure](docs/scenarios/ai-cluster-50mw.md) | Battery supplies IT for 307.8 s; depletion at 607.8 s; utility restoration at 900 s |
+| What happens with healthy 1 MW supply? | [normal](docs/scenarios/normal.md) | 500 kWh served over 30 minutes |
+| Can the 1 MW battery bridge generator startup? | [utility_loss](docs/scenarios/utility_loss.md) | 30-second startup bridged; no unserved load |
+| What if the 1 MW generator also fails? | [generator_failure](docs/scenarios/generator_failure.md) | Battery depletion at 607.8 s; recovery at 900 s |
+| Can one surviving path carry the 1 MW load? | [path_maintenance](docs/scenarios/path_maintenance.md) | 700 kW gross × 0.95 = 665 kW IT; 335 kW unserved |
+| What if both paths share a failed control domain? | [shared_domain](docs/scenarios/shared_domain.md) | Both paths unavailable for 600 s |
 
-## Reproduce the result in Python
+The [worked tutorial](docs/tutorials/continuity-walkthrough.md) develops the surviving-path and finite-battery calculations. The [AI-cluster scenario note](docs/scenarios/ai-cluster-50mw.md) documents the scaled case. Schema-1 PUE/energy planning is a separate calculation from schema-2 continuity; see the [electrical contract](docs/contracts/electrical-v2.md).
 
-The core uses only the standard library. [Run the released CLI or dashboard with one uv command](docs/quickstart.md#run-with-uv), or use Python 3.12+ and a source checkout:
+## Reproduce the 1 MW result in Python
+
+The core uses only the standard library. [Run the released CLI or dashboard with one uv command](docs/quickstart.md#run-with-uv), or use Python 3.12+ and a source checkout. These commands intentionally reproduce the original **1,000 kW / 100 kWh** fixture:
 
 ```sh
 git clone https://github.com/mohammadrezwankhan/datacenter-twin-lab.git
@@ -46,19 +51,7 @@ python -m datacenter_twin simulate --preset generator_failure --format html --ou
 python -m datacenter_twin sweep --preset generator_failure --parameter battery_initial_kwh --values 0 50 100 --format markdown
 ```
 
-Outputs preserve assumptions, units, stable input hashes, warnings, and exact energy ledgers. Unknown costs remain unknown. Existing output files are protected; choose a new path or explicitly use `--force`. The [sensitivity guide](docs/engineering/sensitivity.md) explains the parameters and pre-outage charging. [Example report and reproducibility capsule](docs/validation/reproducibility-capsule.md) include independent equations and artifact hashes.
-
-## Choose a question
-
-| Question | Preset | Expected result |
-| --- | --- | --- |
-| What happens with healthy supply? | [normal](docs/scenarios/normal.md) | 500 kWh served over 30 minutes |
-| Can the battery bridge generator startup? | [utility_loss](docs/scenarios/utility_loss.md) | 30-second startup bridged; no unserved load |
-| What if the generator also fails? | [generator_failure](docs/scenarios/generator_failure.md) | Battery depletion at 607.8 s; recovery at 900 s |
-| Can one surviving path carry the load? | [path_maintenance](docs/scenarios/path_maintenance.md) | 700 kW gross × 0.95 = 665 kW IT; 335 kW unserved |
-| What if both paths share a failed control domain? | [shared_domain](docs/scenarios/shared_domain.md) | Both paths unavailable for 600 s |
-
-The [worked tutorial](docs/tutorials/continuity-walkthrough.md) develops the battery and surviving-path calculations. Schema-1 PUE/energy planning remains a separate calculation from schema-2 continuity; see the [contracts](docs/contracts/electrical-v2.md).
+Outputs preserve assumptions, units, stable input hashes, warnings, and exact energy ledgers. Unknown costs remain unknown. Existing output files are protected; choose a new path or explicitly use `--force`. The [sensitivity guide](docs/engineering/sensitivity.md) explains the parameters and pre-outage charging. The [example report and reproducibility capsule](docs/validation/reproducibility-capsule.md) include independent equations and artifact hashes.
 
 ## Use the local dashboard
 
@@ -74,6 +67,34 @@ python -m unittest discover -s tests -v
 
 CI checks Python 3.12 and 3.14 on Windows and Linux, the installed wheel, local dashboard journeys, and browser/native equality. These checks establish software behavior for the fixtures. **Independent external technical review has not yet been obtained.** The [review protocol](docs/validation/review-protocol.md) provides a bounded worksheet for checking results and reporting mismatches.
 
-Start with [contribution guidance](CONTRIBUTING.md), [beginner contribution ideas](docs/scenarios/contribution-ideas.md), the [roadmap](ROADMAP.md), or [support](SUPPORT.md). Reproducible questions and hand-calculated edge cases are useful contributions. Participants follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+Start with [contribution guidance](CONTRIBUTING.md), [beginner contribution ideas](docs/scenarios/contribution-ideas.md), the [roadmap](ROADMAP.md), or [support](SUPPORT.md). Participants follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 
-Original code and synthetic fixtures use [Apache-2.0](LICENSE); see [NOTICE](NOTICE), [synthetic provenance](data/provenance/manifest.json), and [browser runtime licenses](docs/third-party/README.md). [SOURCE-MANIFEST.json](SOURCE-MANIFEST.json) identifies the original v0.2.0a0 snapshot, not subsequent versions. [Citation metadata](CITATION.cff) accompanies the project; cite the exact release or commit used.
+For a task-based comparison with OpenDC and PyPSA, see [Choosing a simulator](docs/choosing-a-simulator.md).
+
+## Assumptions and limits
+
+This is a deterministic, local-first teaching simulator for a single aggregate IT load. The 50 MW example does not predict GPU throughput, grid adequacy, equipment selection or measured site behavior. The current model covers synthetic utility, generator, finite stored energy, conversion losses, path limits, shared-domain events, deterministic recovery, replay, and exact energy accounting. It does not establish facility calibration, protection coordination, AC transients, cooling behavior, workload queues or throughput, generator ramp/cooldown/fuel dynamics, transfer and switching transients, impedance-based load sharing, harmonics, short-circuit or arc-flash studies, reliability probabilities, Tier claims, service-level claims, certification, physical controls, or physical safety.
+
+| You can use it to | Model boundary |
+| --- | --- |
+| Compare synthetic utility, generator, battery, and path failures | Assumed equipment ratings and efficiencies; no facility calibration |
+| Reproduce event times, energy ledgers, and sensitivity reports | Electrical continuity only; no AC transients, protection, cooling, or workload prediction |
+| Learn, inspect, and share a calculation locally | No physical controls, certified uptime, or facility safety assessment |
+
+The original fixture uses a 1,000 kW IT request, 1,800 s duration, 0.95 distribution efficiency, 100 kWh initial and maximum battery energy, 0.90 discharge efficiency, a 30 s generator start delay, 700 kW path capacities, and a fictional USD 0.10/kWh tariff. The AI-cluster fixture scales demand and battery energy to 50,000 kW and 5,000 kWh while preserving those ratios. These are synthetic inputs. They are not selected-equipment ratings, live prices, a benchmark, a certification, a legal-compliance result, or a real-site calibration.
+
+Schema-1 PUE and energy planning remains separate from schema-2 electrical topology. Neither model silently infers the other. Unknown costs and unavailable quantities stay explicit in reports. The catalogue's dated NVIDIA/model/AWS/Azure/OCI identifiers and one dated Azure East US retail meter are source-backed assumptions, not live feeds, account quotes, capacity allocations, or performance equivalence. Germany, Virginia, and India links are screening pointers, not complete jurisdiction packs or legal advice; India screening must consider the CEA's listed 2026 amendment.
+
+The browser demo has no shared simulation backend or client analytics. The API binds to loopback. No account, GPU, cloud resource, physical control, shared deployment, database, login, tenant isolation, persistent audit, FAT/SAT, or facility telemetry is introduced. Cooling, workload throughput, calibrated alarms, live telemetry, and predictive models remain planned or unvalidated. A 5,000-star aspiration has no validated timeline and is not evidence of model accuracy or adoption.
+
+Local and CI checks cover the core/API suite, frontend format/type/build, installed-wheel verification, local dashboard journeys, browser/Python journeys, and browser/native equality for the synthetic presets. Reference-case timing measures software execution on one local machine; it does not establish scale targets or physical accuracy. These checks are not an independent external review or formal security audit. No facility measurements or validation dataset were used.
+
+The public source tree excludes private manuals, planning references and the private repository history. Do not add private manuals, extracted private text, credentials, customer traces, or licensed standards text.
+
+Original code and synthetic fixtures use [Apache-2.0](LICENSE). See [NOTICE](NOTICE), [synthetic provenance](data/provenance/manifest.json), and [browser runtime licenses](docs/third-party/README.md). [SOURCE-MANIFEST.json](SOURCE-MANIFEST.json) identifies the original v0.2.0a0 snapshot, not subsequent versions. [Citation metadata](CITATION.cff) accompanies the project; cite the exact release or commit used.
+
+[Optional full-size visual concept](docs/images/datacenter-twin-lab-cover-v1.png) (a large artwork asset; it is not part of the initial demo path).
+
+Alpha 0.3.0a0 · Python 3.12+ · Apache-2.0
+
+[![Tests](https://github.com/mohammadrezwankhan/datacenter-twin-lab/actions/workflows/tests.yml/badge.svg)](https://github.com/mohammadrezwankhan/datacenter-twin-lab/actions/workflows/tests.yml)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,28 +1,45 @@
 # Roadmap
 
-Engineering work follows reproducible user needs. Star counts are observations, not release gates or evidence of model accuracy.
+Build from a reproducible outage calculation to experiments an engineer can adapt and teach.
 
-## Available in this source version (0.3.0a0)
+## Available in the source and browser demo
 
-- Deterministic synthetic electrical continuity, finite battery, generator delay/failure, surviving-path limits, shared-domain failure, recovery, and exact energy accounting.
-- A loopback API and dashboard, plus the same Python engine running in a static browser demo without installation or a shared simulation service.
-- Five documented scenarios with diagrams, expected values, and runnable commands.
-- Four bounded sensitivity parameters, JSON exports, and reproducible Markdown/HTML reports.
-- Issue forms, support and conduct guidance, contribution paths, and an external-review worksheet.
-- Windows/Linux numerical tests, installed-wheel checks, local browser journeys, and browser/native result equality.
-- An actual browser walkthrough animation, a hand-calculated teaching notebook, a released-wheel uv route, and readable fallback content when JavaScript cannot start.
+| Capability | What you can do |
+| --- | --- |
+| Seven electrical presets | Compare the five 1 MW reference cases and two 50 MW AI-cluster outage cases. |
+| Twelve interactive lessons | Change one input, predict the result, check a worked answer and export the calculation. |
+| Fast browser calculation | Run locally with exact JavaScript arithmetic; request the Python cross-check when wanted. |
+| Reports and sensitivity | Export JSON, Markdown and HTML; compare bounded reserve, efficiency, demand and delay sweeps. |
+| Python and local dashboard | Reproduce calculations with the standard-library CLI, loopback API and React dashboard. The tagged 0.3.0a0 wheel preserves the earlier five-preset release; use a current source checkout for the AI presets. |
+| Contribution material | Use the glossary, notebook, reproducibility capsule, issue forms and small contribution ideas. |
 
-The [0.2.0a0 release](https://github.com/mohammadrezwankhan/datacenter-twin-lab/releases/tag/v0.2.0a0) remains the earlier continuity/dashboard baseline. Release assets are versioned separately from current source.
+[Start the course](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=power-energy) or [inspect the 50 MW case](docs/scenarios/ai-cluster-50mw.md).
+
+## Next capabilities — planned
+
+1. **Bring your own scenario JSON into the browser.** Validate an imported file, identify the changed assumptions and export a reproducible result.
+2. **Edit a demand timeline visually.** Use the existing demand-event contract to explore ramps represented as explicit steps, without hand-editing JSON.
+3. **Export a lesson worksheet.** Bundle a learner's inputs, prediction, worked calculation and run hash in a printable exercise.
+
+Prioritize these against reproducible first-run problems and learner feedback. They are planned work, not controls already available in the demo.
+
+## Validation methodology
+
+The core and API suites, frontend format/type/build checks, installed-wheel checks, local dashboard journeys, browser/Python journeys, and browser/native equality checks establish software behavior for synthetic fixtures. Numerical expectations use deterministic inputs, explicit units, independent hand calculations, stable input hashes, event logs, interval energy ledgers, and zero energy-balance residuals where the scenario contract requires it. Reference-case timing measures software execution on one local machine; it does not establish a performance benchmark, a scale target, or physical accuracy.
+
+Independent external technical review has not yet been obtained. There is no formal security audit, shared deployment, facility calibration, FAT/SAT, live telemetry, validation dataset, calibrated alarm model, cooling model, workload-throughput model, or physical-control integration. The API remains loopback-only, the browser has no shared simulation backend or client analytics, and unknown costs and unavailable quantities remain explicit. See the [review protocol](docs/validation/review-protocol.md), [reproducibility capsule](docs/validation/reproducibility-capsule.md), and [synthetic provenance manifest](data/provenance/manifest.json).
 
 ## Next evidence to obtain
 
-1. Independent external checks of the [reproducibility capsule](docs/validation/reproducibility-capsule.md), with review scope, corrections, and unresolved limitations recorded publicly.
+1. Independent checks of the [reproducibility capsule](docs/validation/reproducibility-capsule.md), with review scope, corrections, and unresolved limitations recorded publicly.
 2. First-run feedback and scenario reuse by people outside the maintainer workflow; distinguish voluntary reports from automated test activity.
-3. Educator feedback on the [battery ride-through notebook](docs/examples/battery-ride-through.ipynb), including its independently calculated expectations and charging assumptions.
+3. Educator and engineer feedback on the battery ride-through material and the 12-lesson course with reproducible lesson results.
 4. Repeat use, release downloads, forks, Discussions, and contributions measured with explicit sources and denominators. Demo completion remains unknown without voluntary reports; no tracking pixels or client telemetry are installed.
 
-## Deferred until a concrete need is demonstrated
+## Later and deferred work
 
-The released GitHub wheel now supports [uvx](docs/quickstart.md#run-with-uv). Publishing that package on PyPI needs a configured owner publishing identity. Additional sweep parameters, optional public-data adapters, a stable extension API, and carefully bounded synthetic GPU/rack examples need separate contracts and provenance. 3D scenes, operational integrations, and a new fluent API do not take priority over reproducibility and first-run feedback.
+The released GitHub wheel supports [uvx](docs/quickstart.md#run-with-uv). Publishing on PyPI needs a configured owner publishing identity. Additional sweep parameters, optional public-data adapters, a stable extension API, and carefully bounded synthetic GPU/rack examples need separate contracts and provenance. 3D scenes, operational integrations, and a new fluent API do not take priority over reproducibility and first-run feedback.
 
-A shared multi-user service, live facility telemetry, cooling/workload prediction, calibrated alarms, physical controls, and certification claims are outside the current project scope. A 5,000-star aspiration has no validated timeline and is not a reason to broaden those claims.
+A shared multi-user service, live facility telemetry, cooling/workload prediction, calibrated alarms, physical controls, and certification claims remain outside the current project scope. No star target is a validated schedule or evidence of model accuracy or adoption.
+
+Original code and synthetic fixtures use [Apache-2.0](LICENSE); see [NOTICE](NOTICE) and the [browser runtime licenses](docs/third-party/README.md).

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -6,7 +6,7 @@
     <meta name="theme-color" content="#0b1018" />
     <meta
       name="description"
-      content="A local-first power-continuity simulator. Change a synthetic battery reserve, replay generator failure and recovery, and export reproducible results."
+      content="A local-first power-continuity simulator. Change the battery reserve, replay generator failure and recovery, and export reproducible results."
     />
     <title>Datacenter Twin Lab</title>
   </head>
@@ -19,13 +19,13 @@
         <p>A reproducible, local-first power-continuity what-if simulator.</p>
         <h2>A generator fails. How long does the battery last?</h2>
         <p>
-          In the opening synthetic example, a 100 kWh battery serves a 1 MW load for 307.8 seconds
+          In the opening 50 MW example, a 5 MWh battery serves the requested load for 307.8 seconds
           after utility and generator fail. Utility returns at 900 seconds elapsed. Change the
           battery reserve to compare depletion and recovery, then export the calculation.
         </p>
         <p>
-          The interactive interface starts automatically when its scripts load. The hosted demo
-          needs JavaScript and WebAssembly and downloads about 14 MB on its first visit.
+          The interactive interface starts automatically when its scripts load. The hosted demo uses
+          JavaScript. Optional Python verification downloads its runtime only when you request it.
           Calculations run on your device; no account is required.
         </p>
         <noscript>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,10 +7,11 @@
     "dev": "vite --host 127.0.0.1",
     "build": "tsc --noEmit && vite build",
     "test:e2e": "playwright test",
-    "format": "prettier --write src tests tests-demo *.ts *.json index.html",
-    "format:check": "prettier --check src tests tests-demo *.ts *.json index.html",
+    "format": "prettier --write src tests tests-demo tests-engine *.ts *.json index.html",
+    "format:check": "prettier --check src tests tests-demo tests-engine *.ts *.json index.html",
     "build:demo": "tsc --noEmit && vite build --mode demo",
-    "test:demo": "playwright test --config playwright.demo.config.ts"
+    "test:demo": "playwright test --config playwright.demo.config.ts",
+    "test:engine": "node --experimental-strip-types --loader ./tests-engine/resolve-loader.mjs --test tests-engine/*.test.ts"
   },
   "dependencies": {
     "react": "19.2.8",

--- a/apps/web/scripts/record-demo.mjs
+++ b/apps/web/scripts/record-demo.mjs
@@ -7,7 +7,7 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const root = fileURLToPath(new URL('../../../', import.meta.url));
-const url = process.argv[2] || 'http://127.0.0.1:4175/datacenter-twin-lab/';
+const url = process.argv[2] || 'http://127.0.0.1:4175/datacenter-twin-lab/?preset=generator_failure';
 const output = resolve(root, process.argv[3] || '.local/demo-recording');
 await mkdir(dirname(output), { recursive: true });
 await mkdir(output); // A new output directory prevents overwriting earlier evidence.

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,9 +3,13 @@ import type { Asset, Catalog, Interval, Run, SiteScenario } from './types';
 import { Evidence } from './Evidence';
 import { n, request } from './client';
 import { RunTools } from './RunTools';
+import { PythonVerification } from './PythonVerification';
+import { Course } from './Course';
 
 const browserDemo = import.meta.env.MODE === 'demo';
-const initialPreset = browserDemo ? 'generator_failure' : 'utility_loss';
+const initialPreset = browserDemo
+  ? new URLSearchParams(window.location.search).get('preset') || 'ai_cluster_generator_failure'
+  : 'utility_loss';
 
 const clock = (seconds: string | number) =>
   `${Math.floor(Number(seconds) / 60)
@@ -312,7 +316,9 @@ function Compare({ baseline, run }: { baseline: Run; run: Run }) {
 }
 
 export function App() {
-  const [page, setPage] = useState<'overview' | 'topology' | 'evidence'>('overview');
+  const [page, setPage] = useState<'overview' | 'topology' | 'evidence' | 'learn'>(
+    browserDemo && new URLSearchParams(window.location.search).has('lesson') ? 'learn' : 'overview',
+  );
   const [draft, setDraft] = useState<SiteScenario | null>(null),
     [run, setRun] = useState<Run | null>(null);
   const [catalog, setCatalog] = useState<Catalog | null>(null),
@@ -327,19 +333,25 @@ export function App() {
     [notice, setNotice] = useState('');
   const active = useRef<AbortController | null>(null);
   const dirty = !!draft && !!run && JSON.stringify(draft) !== JSON.stringify(run.scenario);
+  function navigate(next: typeof page) {
+    setPage(next);
+    if (next !== 'learn') {
+      const url = new URL(window.location.href);
+      url.searchParams.delete('lesson');
+      window.history.replaceState(null, '', url);
+    }
+  }
   useEffect(() => {
     const controller = new AbortController();
     active.current = controller;
     (async () => {
       try {
-        const [p, c, d] = await Promise.all([
+        const [p, d] = await Promise.all([
           request<typeof presets>('presets', controller.signal),
-          request<Catalog>('catalog', controller.signal),
           request<SiteScenario>(`demo?preset=${initialPreset}`, controller.signal),
         ]);
         const r = await request<Run>('simulations', controller.signal, d);
         setPresets(p);
-        setCatalog(c);
         setDraft(d);
         setRun(r);
         setBusy(false);
@@ -352,6 +364,16 @@ export function App() {
     })();
     return () => controller.abort();
   }, []);
+  useEffect(() => {
+    if (page !== 'evidence' || catalog) return;
+    const controller = new AbortController();
+    request<Catalog>('catalog', controller.signal)
+      .then(setCatalog)
+      .catch((cause) => {
+        if (!controller.signal.aborted) setError((cause as Error).message);
+      });
+    return () => controller.abort();
+  }, [page, catalog]);
   useEffect(() => {
     if (!playing || !run) return;
     const timer = window.setInterval(
@@ -416,7 +438,7 @@ export function App() {
           href="#"
           onClick={(e) => {
             e.preventDefault();
-            setPage('overview');
+            navigate('overview');
           }}
           aria-label="Datacenter Twin Lab home"
         >
@@ -429,7 +451,8 @@ export function App() {
         <nav aria-label="Main navigation">
           {(
             [
-              ['overview', '◫', 'Overview'],
+              ['overview', '◫', browserDemo ? 'Simulator' : 'Overview'],
+              ...(browserDemo ? [['learn', '▹', '12 browser lessons'] as const] : []),
               ['topology', '⌘', 'Power topology'],
               ['evidence', '▤', 'Evidence & options'],
             ] as const
@@ -438,7 +461,7 @@ export function App() {
               key={id}
               className={page === id ? 'nav-item current' : 'nav-item'}
               aria-current={page === id ? 'page' : undefined}
-              onClick={() => setPage(id)}
+              onClick={() => navigate(id)}
             >
               <span aria-hidden="true">{icon}</span>
               {label}
@@ -448,17 +471,17 @@ export function App() {
         <div className="sidebar-bottom">
           <span className="status-dot" /> {browserDemo ? 'Browser workspace' : 'Local workspace'}
           <p>
-            Synthetic reference site
+            Power continuity scenarios
             <br />
             Engine {run?.engine_version || 'loading'}
           </p>
-          <span className="mini-tag">No live equipment</span>
+          <span className="mini-tag">Local calculations</span>
         </div>
       </aside>
       <div className="main-shell">
         <header className="topbar">
           <span className="breadcrumb">
-            Research workspace <span>/</span> <b>Reference site 01</b>
+            Power systems <span>/</span> <b>Datacenter engineers</b>
           </span>
           <span className="mode-badge">
             <i /> SIMULATED
@@ -469,48 +492,51 @@ export function App() {
             <div>
               <div className="eyebrow">ELECTRICAL CONTINUITY LAB</div>
               <h1>
-                {page === 'evidence'
-                  ? 'Evidence & options'
-                  : page === 'topology'
-                    ? 'Power topology'
-                    : 'Site overview'}
+                {page === 'learn'
+                  ? 'Power systems for datacenter engineers'
+                  : page === 'evidence'
+                    ? 'Evidence & options'
+                    : page === 'topology'
+                      ? 'Power topology'
+                      : 'Site overview'}
               </h1>
               <p>
-                {page === 'evidence'
-                  ? 'Trace each option to a source. Keep unknowns visible.'
-                  : 'Explore supply interruptions across a synthetic 1 MW site.'}
+                {page === 'learn'
+                  ? 'Twelve experiments. Change an input, predict the result, then test it.'
+                  : page === 'evidence'
+                    ? 'Trace the inputs and options behind each calculation.'
+                    : 'Change the load or reserve and see exactly when service is interrupted.'}
               </p>
             </div>
-            <div className="heading-actions">
-              <button
-                disabled={!run || busy}
-                onClick={() => {
-                  setBaseline(run);
-                  setNotice('Baseline saved for this session.');
-                }}
-              >
-                Save baseline
-              </button>
-              <button disabled={!run} onClick={exportRun}>
-                Export run <span aria-hidden="true">↗</span>
-              </button>
-            </div>
+            {page !== 'learn' && (
+              <div className="heading-actions">
+                <button
+                  disabled={!run || busy}
+                  onClick={() => {
+                    setBaseline(run);
+                    setNotice('Baseline saved for this session.');
+                  }}
+                >
+                  Save baseline
+                </button>
+                <button disabled={!run} onClick={exportRun}>
+                  Export run <span aria-hidden="true">↗</span>
+                </button>
+              </div>
+            )}
           </div>
-          {browserDemo && (
+          {browserDemo && page === 'overview' && (
             <section className="panel demo-intro" aria-label="Start here">
               <div className="eyebrow">NO INSTALLATION · RUNS ON YOUR DEVICE</div>
-              <h2>Can the battery bridge a failed generator?</h2>
+              <h2>What happens when a 50 MW AI cluster loses power?</h2>
               <p>
-                Start with a synthetic 1 MW site. Both utility and generator fail at 300 s; utility
-                returns at 900 s. Change the initial battery from 100 to 50 kWh, run again, and
-                export the result.
+                The opening 50 MW example has 5 MWh stored energy: with the stated losses, that is
+                307.8 seconds of battery support after both supplies fail. Select a case below,
+                change the reserve, and inspect how your result changes.
               </p>
-              <p>
-                The original Python engine runs in this browser. Inputs stay on your device. This is
-                a synthetic electrical model; facility calibration, cooling and GPU performance are
-                outside its scope.
-              </p>
+              <p>Runs locally in JavaScript. Python verification is available after the result.</p>
               <div className="tool-actions">
+                <button onClick={() => setPage('learn')}>Start the 12-lesson course</button>
                 <a href="https://github.com/mohammadrezwankhan/datacenter-twin-lab/blob/main/docs/scenarios/index.md">
                   Scenario catalog ↗
                 </a>
@@ -518,34 +544,37 @@ export function App() {
                   Share a reproducible finding ↗
                 </a>
               </div>
-              {run && run.scenario.id === 'demo-generator_failure' && (
-                <div className="demo-stages">
-                  {[
-                    ['Supply fails', 300],
-                    [
-                      'Battery depleted',
-                      run.events.find((e) => e.action === 'battery_depleted')?.at_s,
-                    ],
-                    ['Utility recovers', 900],
-                  ].map(
-                    ([label, at]) =>
-                      at !== undefined && (
-                        <button
-                          key={label}
-                          onClick={() => {
-                            setPlaying(false);
-                            const index = run.intervals.findIndex(
-                              (interval) => Number(interval.start_s) >= Number(at),
-                            );
-                            setCursor(Math.max(0, index));
-                          }}
-                        >
-                          {label} <strong>{n(at, 1)} s</strong>
-                        </button>
-                      ),
-                  )}
-                </div>
-              )}
+              {run &&
+                ['demo-generator_failure', 'demo-ai_cluster_generator_failure'].includes(
+                  run.scenario.id,
+                ) && (
+                  <div className="demo-stages">
+                    {[
+                      ['Supply fails', 300],
+                      [
+                        'Battery depleted',
+                        run.events.find((e) => e.action === 'battery_depleted')?.at_s,
+                      ],
+                      ['Utility recovers', 900],
+                    ].map(
+                      ([label, at]) =>
+                        at !== undefined && (
+                          <button
+                            key={label}
+                            onClick={() => {
+                              setPlaying(false);
+                              const index = run.intervals.findIndex(
+                                (interval) => Number(interval.start_s) >= Number(at),
+                              );
+                              setCursor(Math.max(0, index));
+                            }}
+                          >
+                            {label} <strong>{n(at, 1)} s</strong>
+                          </button>
+                        ),
+                    )}
+                  </div>
+                )}
             </section>
           )}
           {error && (
@@ -562,14 +591,20 @@ export function App() {
           {!run && !error && (
             <div className="panel loading" role="status">
               {browserDemo
-                ? 'Loading browser Python (about 14 MB on first visit), then calculating the scenario…'
+                ? 'Calculating the opening scenario on your device…'
                 : 'Preparing the reference simulation…'}
             </div>
           )}
           {run && row && draft && (
             <>
-              {page === 'evidence' ? (
-                catalog && <Evidence catalog={catalog} run={run} />
+              {page === 'learn' ? (
+                <Course />
+              ) : page === 'evidence' ? (
+                catalog ? (
+                  <Evidence catalog={catalog} run={run} />
+                ) : (
+                  <p role="status">Loading reference options…</p>
+                )
               ) : (
                 <>
                   <form
@@ -893,11 +928,17 @@ export function App() {
                   </section>
                   {baseline && <Compare baseline={baseline} run={run} />}
                   <RunTools run={run} />
+                  {browserDemo && <PythonVerification run={run} />}
                   <details className="panel assumptions">
                     <summary>
                       Model boundary & run evidence <span>Synthetic · uncalibrated</span>
                     </summary>
                     <p>{run.boundary}</p>
+                    <p>
+                      The scenarios are synthetic and uncalibrated. Facility safety, cooling and GPU
+                      performance, certified uptime and live equipment control are not established.
+                      Independent external technical review has not yet been obtained.
+                    </p>
                     <ul>
                       {run.limitations.map((l) => (
                         <li key={l}>{l}</li>

--- a/apps/web/src/Course.tsx
+++ b/apps/web/src/Course.tsx
@@ -1,0 +1,277 @@
+import { useEffect, useRef, useState } from 'react';
+import { lessons, lessonScenario } from './course-lessons';
+import { n, request } from './client';
+import type { Run, SiteScenario } from './types';
+import { RunTools } from './RunTools';
+import { PythonVerification } from './PythonVerification';
+
+type Planning = {
+  schema_version: 1;
+  run_id: string;
+  input_sha256: string;
+  assumptions: Record<string, unknown>;
+  facility_energy_kwh: string;
+  it_energy_kwh: string;
+  non_it_energy_kwh: string;
+  limitations: string[];
+};
+
+export function Course() {
+  const route = new URLSearchParams(window.location.search).get('lesson');
+  const [id, setId] = useState(lessons.some((item) => item.id === route) ? route! : lessons[0].id);
+  const lesson = lessons.find((item) => item.id === id)!;
+  const [value, setValue] = useState(lesson.initial);
+  const [usedValue, setUsedValue] = useState('');
+  const [run, setRun] = useState<Run | null>(null);
+  const [planning, setPlanning] = useState<Planning | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [answer, setAnswer] = useState(false);
+  const active = useRef<AbortController | null>(null);
+  const position = lessons.indexOf(lesson);
+
+  async function calculate(input: string) {
+    active.current?.abort();
+    const controller = new AbortController();
+    active.current = controller;
+    setBusy(true);
+    setError('');
+    try {
+      const base = await request<SiteScenario>(`demo?preset=${lesson.preset}`, controller.signal);
+      const scenario = lessonScenario(lesson, base, input);
+      if (lesson.id === 'pue') {
+        const result = await request<Planning>('planning', controller.signal, {
+          schema_version: 1,
+          id: 'course-pue',
+          name: '50 MW annual energy planning',
+          currency: 'USD',
+          it_capacity_kw: '50000',
+          tariff_per_kwh: null,
+          price_status: 'unknown',
+          assumption_date: '2026-09-12',
+          source_ids: ['EDU-POWER-001'],
+          segments: [
+            {
+              label: 'Assumed constant annual load',
+              hours: '8760',
+              it_load_kw: '50000',
+              assumed_pue: input,
+            },
+          ],
+        });
+        if (controller.signal.aborted) return;
+        setPlanning(result);
+        setRun(null);
+      } else {
+        const result = await request<Run>('simulations', controller.signal, scenario);
+        if (controller.signal.aborted) return;
+        setRun(result);
+        setPlanning(null);
+      }
+      setUsedValue(input);
+    } catch (cause) {
+      if (!controller.signal.aborted) setError((cause as Error).message);
+    } finally {
+      if (!controller.signal.aborted) setBusy(false);
+    }
+  }
+  useEffect(() => {
+    setValue(lesson.initial);
+    setUsedValue('');
+    setRun(null);
+    setPlanning(null);
+    setAnswer(false);
+    void calculate(lesson.initial);
+    const url = new URL(window.location.href);
+    url.searchParams.set('lesson', lesson.id);
+    window.history.replaceState(null, '', url);
+    return () => active.current?.abort();
+  }, [id]);
+
+  const generatorId = run?.scenario.assets.find((asset) => asset.kind === 'generator')?.id;
+  const eventValue =
+    lesson.resultKey === 'depletion'
+      ? run?.events.find((event) => event.action === 'battery_depleted')?.at_s
+      : run?.intervals.find(
+          (interval) => generatorId && interval.asset_states[generatorId] === 'running',
+        )?.start_s;
+  const result =
+    planning?.facility_energy_kwh ??
+    (['depletion', 'generator_ready'].includes(lesson.resultKey)
+      ? eventValue
+      : run?.summary[lesson.resultKey]);
+  return (
+    <div className="course" data-testid="course">
+      <section className="panel course-navigation">
+        <label>
+          Choose a lesson
+          <select value={id} onChange={(event) => setId(event.target.value)}>
+            {lessons.map((item) => (
+              <option value={item.id} key={item.id}>
+                {item.title}
+              </option>
+            ))}
+          </select>
+        </label>
+        <p>
+          Start with power and energy, then test failures, storage and AI-scale demand. Each lesson
+          has one input to change and a worked answer. No installation or account.
+        </p>
+        <progress value={position + 1} max={lessons.length} aria-label="Lesson position" />
+        <span>
+          Lesson {position + 1} of {lessons.length}
+        </span>
+      </section>
+      <section className="panel course-experiment" aria-label="Lesson experiment">
+        <div className="eyebrow">{lesson.concept}</div>
+        <h2>{lesson.title}</h2>
+        <p className="course-question">{lesson.question}</p>
+        <p>
+          Predict the result for{' '}
+          <strong>
+            {lesson.challenge} {lesson.unit}
+          </strong>{' '}
+          before running the change.
+        </p>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            void calculate(value);
+          }}
+        >
+          <label>
+            {lesson.label} {lesson.unit && `(${lesson.unit})`}
+            <input
+              type="number"
+              value={value}
+              min={lesson.min}
+              max={lesson.max}
+              step={lesson.step}
+              onChange={(event) => setValue(event.target.value)}
+            />
+          </label>
+          <div className="tool-actions">
+            <button type="submit" disabled={busy}>
+              Run lesson
+            </button>
+            <button type="button" onClick={() => setValue(lesson.challenge)}>
+              Try the challenge value
+            </button>
+            <button type="button" onClick={() => setValue(lesson.initial)}>
+              Reset input
+            </button>
+          </div>
+        </form>
+        {busy && <p role="status">Calculating lesson…</p>}
+        {error && <p role="alert">{error}</p>}
+        {usedValue && value !== usedValue && (
+          <p className="notice">Input changed. Run the lesson to update the result.</p>
+        )}
+        {!busy && (run || planning) && (
+          <div className="course-result" data-testid="lesson-result">
+            <span>
+              Result for {usedValue} {lesson.unit}
+            </span>
+            <strong>
+              {result === undefined ? 'No event' : n(result, 6)}{' '}
+              {result !== undefined && lesson.resultUnit}
+            </strong>
+            {run && (
+              <p>
+                Unserved energy: {n(run.summary.unserved_it_kwh, 6)} kWh · Energy balance residual:{' '}
+                {run.summary.energy_balance_residual_kwh} kWh
+              </p>
+            )}
+            {planning && (
+              <p>
+                IT energy: {n(planning.it_energy_kwh, 0)} kWh · Non-IT energy:{' '}
+                {n(planning.non_it_energy_kwh, 0)} kWh
+              </p>
+            )}
+          </div>
+        )}
+        <button className="answer-button" aria-expanded={answer} onClick={() => setAnswer(!answer)}>
+          {answer ? 'Hide worked answer' : 'Show worked answer'}
+        </button>
+        {answer && <p className="worked-answer">{lesson.explanation}</p>}
+        <div className="tool-actions lesson-paging">
+          <button disabled={position === 0} onClick={() => setId(lessons[position - 1].id)}>
+            Previous lesson
+          </button>
+          <button
+            disabled={position === lessons.length - 1}
+            onClick={() => setId(lessons[position + 1].id)}
+          >
+            Next lesson
+          </button>
+        </div>
+      </section>
+      {run && (
+        <>
+          <section className="panel">
+            <button
+              onClick={() => {
+                const url = URL.createObjectURL(
+                  new Blob([JSON.stringify(run, null, 2)], { type: 'application/json' }),
+                );
+                const link = document.createElement('a');
+                link.href = url;
+                link.download = `lesson-${lesson.id}-${run.run_id}.json`;
+                link.click();
+                setTimeout(() => URL.revokeObjectURL(url), 1000);
+              }}
+            >
+              Export lesson run
+            </button>
+          </section>
+          <RunTools run={run} />
+          <PythonVerification run={run} />
+        </>
+      )}
+      {planning && (
+        <>
+          <section className="panel">
+            <button
+              onClick={() => {
+                const url = URL.createObjectURL(
+                  new Blob([JSON.stringify(planning, null, 2)], { type: 'application/json' }),
+                );
+                const link = document.createElement('a');
+                link.href = url;
+                link.download = 'pue-lesson.json';
+                link.click();
+                setTimeout(() => URL.revokeObjectURL(url), 1000);
+              }}
+            >
+              Export PUE calculation
+            </button>
+          </section>
+          <PythonVerification run={planning} />
+        </>
+      )}
+      <details className="panel assumptions">
+        <summary>Lesson assumptions and limits</summary>
+        <p>
+          These are original synthetic electrical and energy-planning exercises. Ratings, event
+          times, storage and efficiencies are assumptions, not selected equipment or measurements
+          from a facility.
+        </p>
+        <p>
+          The 50 MW examples model aggregate requested IT power. They do not predict GPU jobs,
+          cooling, grid adequacy, AC transients, protection, facility safety, reliability
+          probabilities or certified uptime. The N+1 lesson examines a path-capacity condition only.
+          PUE is a separate energy calculation.
+        </p>
+        <p>
+          No physical controls or external telemetry are used. Independent external technical review
+          has not yet been obtained.
+        </p>
+        <p>
+          Worked answers describe the default and challenge values. Other inputs may change the
+          event sequence. All input hashes and limitations travel with exports. Lesson completion is
+          not collected.
+        </p>
+      </details>
+    </div>
+  );
+}

--- a/apps/web/src/PythonVerification.tsx
+++ b/apps/web/src/PythonVerification.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+import type { Run } from './types';
+
+function ordered(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(ordered);
+  if (value !== null && typeof value === 'object')
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+        .map(([key, child]) => [key, ordered(child)]),
+    );
+  return value;
+}
+
+type PlanningVerification = {
+  schema_version: 1;
+  run_id: string;
+  assumptions: Record<string, unknown>;
+};
+export function PythonVerification({ run }: { run: Run | PlanningVerification }) {
+  const [enabled, setEnabled] = useState(false);
+  const [attempt, setAttempt] = useState(0);
+  const [status, setStatus] = useState('');
+  const [error, setError] = useState('');
+  useEffect(() => {
+    setStatus('');
+    setError('');
+    if (!enabled) return;
+    const controller = new AbortController();
+    setStatus('Loading Python on request and checking this completed run…');
+    (async () => {
+      try {
+        const { pythonRequest } = await import('./python-client');
+        const reference = await pythonRequest<unknown>(
+          run.schema_version === 1 ? 'planning' : 'simulations',
+          controller.signal,
+          run.schema_version === 1 ? run.assumptions : run.scenario,
+        );
+        if (controller.signal.aborted) return;
+        if (JSON.stringify(ordered(reference)) !== JSON.stringify(ordered(run)))
+          throw new Error(
+            'JavaScript and Python results differ. Export this run and report the mismatch.',
+          );
+        setStatus(
+          `Exact match with Python: all inputs, hashes and calculated values (${run.run_id}).`,
+        );
+      } catch (cause) {
+        if (!controller.signal.aborted) {
+          setStatus('');
+          setError((cause as Error).message);
+        }
+      }
+    })();
+    return () => controller.abort();
+  }, [enabled, attempt, run]);
+  return (
+    <section className="panel python-verification" aria-label="Optional Python verification">
+      <label>
+        <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
+        Verify against Python
+      </label>
+      <p>
+        Optional: downloads about 14 MB the first time. Your existing result stays available; the
+        reference Python engine also runs on your device.
+      </p>
+      {status && (
+        <p role="status" data-testid="python-verification-status">
+          {status}
+        </p>
+      )}
+      {error && (
+        <div role="alert">
+          <p>{error}</p>
+          <button onClick={() => setAttempt((value) => value + 1)}>
+            Retry Python verification
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/browser-client.ts
+++ b/apps/web/src/browser-client.ts
@@ -1,60 +1,7 @@
-type Pending = {
-  resolve: (value: unknown) => void;
-  reject: (error: Error) => void;
-  cleanup: () => void;
-};
-let worker: Worker | undefined;
-let sequence = 0;
-const pending = new Map<number, Pending>();
+import { createWorkerRequest } from './worker-request';
 
-function stop(error: Error) {
-  worker?.terminate();
-  worker = undefined;
-  for (const item of pending.values()) {
-    item.cleanup();
-    item.reject(error);
-  }
-  pending.clear();
-}
-
-export function browserRequest<T>(path: string, signal?: AbortSignal, body?: unknown): Promise<T> {
-  if (signal?.aborted) return Promise.reject(new DOMException('Cancelled', 'AbortError'));
-  const json = JSON.stringify(body ?? null);
-  if (new TextEncoder().encode(json).byteLength > 4 * 1024 * 1024)
-    return Promise.reject(new Error('Request exceeds the 4 MiB input limit'));
-  if (!worker) {
-    worker = new Worker(new URL('./browser-worker.ts', import.meta.url), { type: 'module' });
-    worker.onmessage = ({ data }) => {
-      const item = pending.get(data.id);
-      if (!item) return;
-      pending.delete(data.id);
-      item.cleanup();
-      if (data.error) item.reject(new Error(data.error));
-      else item.resolve(data.result);
-    };
-    worker.onerror = () => stop(new Error('Browser Python could not start. Reload to retry.'));
-  }
-  return new Promise<T>((resolve, reject) => {
-    const id = ++sequence;
-    const abort = () => {
-      const item = pending.get(id);
-      pending.delete(id);
-      item?.cleanup();
-      reject(new DOMException('Cancelled', 'AbortError'));
-    };
-    const timer = setTimeout(
-      () => stop(new Error('Browser calculation timed out. Try a smaller scenario or reload.')),
-      90_000,
-    );
-    pending.set(id, {
-      resolve: (value) => resolve(value as T),
-      reject,
-      cleanup: () => {
-        clearTimeout(timer);
-        signal?.removeEventListener('abort', abort);
-      },
-    });
-    signal?.addEventListener('abort', abort, { once: true });
-    worker!.postMessage({ id, path, body: json });
-  });
-}
+// The interactive path never imports or starts the optional Python runtime.
+export const browserRequest = createWorkerRequest(
+  () => new Worker(new URL('./javascript-worker.ts', import.meta.url), { type: 'module' }),
+  'Browser calculation',
+);

--- a/apps/web/src/browser-worker.ts
+++ b/apps/web/src/browser-worker.ts
@@ -31,7 +31,10 @@ self.addEventListener('message', (event: MessageEvent) => {
   const { id, path, body } = event.data;
   queue = queue.then(async () => {
     try {
-      const py = await (runtime ??= initialize());
+      const py = await (runtime ??= initialize().catch((error) => {
+        runtime = undefined;
+        throw error;
+      }));
       py.globals.set('_request_path', path);
       py.globals.set('_request_json', body);
       const value = py.runPython('_bridge_dispatch(_request_path, _request_json)');

--- a/apps/web/src/course-lessons.ts
+++ b/apps/web/src/course-lessons.ts
@@ -1,0 +1,309 @@
+import type { SiteScenario } from './types';
+
+export type Lesson = {
+  id: string;
+  title: string;
+  concept: string;
+  question: string;
+  preset: string;
+  label: string;
+  unit: string;
+  initial: string;
+  challenge: string;
+  min: number;
+  max: number;
+  step: number;
+  field: string;
+  resultKey: string;
+  resultUnit: string;
+  explanation: string;
+};
+
+export const lessons: Lesson[] = [
+  {
+    id: 'power-energy',
+    title: '1. Power becomes energy',
+    concept: 'kW and kWh',
+    question: 'How much energy does a constant load request in half an hour?',
+    preset: 'normal',
+    label: 'IT demand',
+    unit: 'kW',
+    initial: '1000',
+    challenge: '500',
+    min: 0,
+    max: 1000,
+    step: 100,
+    field: 'it_demand_kw',
+    resultKey: 'requested_it_kwh',
+    resultUnit: 'kWh',
+    explanation:
+      'Energy equals power multiplied by time. At 1,000 kW for 0.5 h the request is 500 kWh; at 500 kW it is 250 kWh.',
+  },
+  {
+    id: 'distribution-loss',
+    title: '2. Account for distribution losses',
+    concept: 'Efficiency',
+    question: 'How much source power is needed to deliver 1,000 kW?',
+    preset: 'normal',
+    label: 'Distribution efficiency',
+    unit: 'ratio',
+    initial: '0.95',
+    challenge: '0.90',
+    min: 0.5,
+    max: 1,
+    step: 0.01,
+    field: 'distribution_efficiency',
+    resultKey: 'grid_kwh',
+    resultUnit: 'kWh over 30 min',
+    explanation:
+      'Divide the IT demand by efficiency. At 0.95 the source supplies 1,052.631… kW; at 0.90 it supplies 1,111.111… kW.',
+  },
+  {
+    id: 'ride-through',
+    title: '3. Calculate battery ride-through',
+    concept: 'Finite storage',
+    question: 'Does half the stored energy give half the ride-through duration?',
+    preset: 'generator_failure',
+    label: 'Initial battery',
+    unit: 'kWh',
+    initial: '100',
+    challenge: '50',
+    min: 0,
+    max: 100,
+    step: 10,
+    field: 'battery_initial_kwh',
+    resultKey: 'depletion',
+    resultUnit: 's elapsed',
+    explanation:
+      'Charging is disabled in this lesson. 100 kWh delivers 85.5 kWh after the two losses: 307.8 s of ride-through. 50 kWh gives 153.9 s, so depletion is at 453.9 s elapsed.',
+  },
+  {
+    id: 'generator-delay',
+    title: '4. Bridge generator startup',
+    concept: 'Sequence and delay',
+    question: 'What changes when startup takes 60 seconds instead of 30?',
+    preset: 'utility_loss',
+    label: 'Generator start delay',
+    unit: 's',
+    initial: '30',
+    challenge: '60',
+    min: 0,
+    max: 600,
+    step: 10,
+    field: 'generator_start_delay_s',
+    resultKey: 'generator_ready',
+    resultUnit: 's elapsed',
+    explanation:
+      'A utility failure at 300 s requests a start. A 30 s delay makes the generator ready at 330 s; a 60 s delay makes it ready at 360 s. The battery bridges both in these inputs.',
+  },
+  {
+    id: 'generator-failure',
+    title: '5. Add a failed generator',
+    concept: 'Combined failures',
+    question: 'What changes if the generator cannot start?',
+    preset: 'generator_failure',
+    label: 'Generator available (0 = failed, 1 = available)',
+    unit: '',
+    initial: '0',
+    challenge: '1',
+    min: 0,
+    max: 1,
+    step: 1,
+    field: 'generator_available',
+    resultKey: 'unserved_duration_s',
+    resultUnit: 's unserved',
+    explanation:
+      'With the generator failed, the battery empties at 607.8 s and service is lost for 292.2 s. An available generator starts after 30 s and avoids that gap.',
+  },
+  {
+    id: 'n-plus-one',
+    title: '6. Check a surviving path',
+    concept: 'N+1 capacity reasoning',
+    question: 'Are two paths enough when either one must carry the whole load?',
+    preset: 'path_maintenance',
+    label: 'Each path gross capacity',
+    unit: 'kW',
+    initial: '700',
+    challenge: '1100',
+    min: 100,
+    max: 1500,
+    step: 100,
+    field: 'path_capacity',
+    resultKey: 'peak_unserved_kw',
+    resultUnit: 'kW unserved',
+    explanation:
+      'One 700 kW path delivers 665 kW after losses, leaving 335 kW unmet. One 1,100 kW path can deliver the full 1,000 kW request. This tests a capacity condition, not a complete N+1 classification.',
+  },
+  {
+    id: 'shared-controls',
+    title: '7. Expose shared control failures',
+    concept: 'Failure domains',
+    question: 'Can a shared control fault defeat both power paths?',
+    preset: 'shared_domain',
+    label: 'Path B shares failed controls (0 = no, 1 = yes)',
+    unit: '',
+    initial: '1',
+    challenge: '0',
+    min: 0,
+    max: 1,
+    step: 1,
+    field: 'shared_controls',
+    resultKey: 'peak_unserved_kw',
+    resultUnit: 'kW unserved',
+    explanation:
+      'Both paths share the failed control domain initially: 1,000 kW is unmet. Removing that dependency from path B preserves its 665 kW delivery, leaving 335 kW unmet.',
+  },
+  {
+    id: 'single-point',
+    title: '8. Find a single point of failure',
+    concept: 'Common upstream assets',
+    question: 'What happens to two paths when their common main bus fails?',
+    preset: 'normal',
+    label: 'Main bus available (0 = failed, 1 = available)',
+    unit: '',
+    initial: '0',
+    challenge: '1',
+    min: 0,
+    max: 1,
+    step: 1,
+    field: 'main_bus_available',
+    resultKey: 'unserved_it_kwh',
+    resultUnit: 'kWh unserved',
+    explanation:
+      'The common bus outage lasts 600 s. Even with two downstream paths, 1,000 × 600/3,600 = 166.666… kWh is unserved. Keeping the bus available removes the interruption.',
+  },
+  {
+    id: 'precharge',
+    title: '9. Track energy before the outage',
+    concept: 'Opening balances',
+    question: 'Why does the 50 kWh case last longer when it can charge first?',
+    preset: 'generator_failure',
+    label: 'Battery charging power',
+    unit: 'kW',
+    initial: '100',
+    challenge: '0',
+    min: 0,
+    max: 100,
+    step: 10,
+    field: 'battery_charge_kw',
+    resultKey: 'depletion',
+    resultUnit: 's elapsed',
+    explanation:
+      'The battery starts at 50 kWh. Before the 300 s outage it gains 7.9166… kWh at 100 kW charging power. Depletion is at 478.2675 s; with charging disabled it is at 453.9 s.',
+  },
+  {
+    id: 'ai-outage',
+    title: '10. Interrupt a 50 MW AI cluster',
+    concept: 'Aggregate AI power demand',
+    question: 'How long can 5 MWh of stored energy bridge a 50 MW load?',
+    preset: 'ai_cluster_generator_failure',
+    label: 'Initial battery',
+    unit: 'kWh',
+    initial: '5000',
+    challenge: '2500',
+    min: 0,
+    max: 5000,
+    step: 500,
+    field: 'battery_initial_kwh',
+    resultKey: 'depletion',
+    resultUnit: 's elapsed',
+    explanation:
+      'Scaling the electrical ratings and storage by 50 preserves the 307.8 s ride-through duration. Halving initial reserve gives depletion at 478.2675 s with pre-outage charging. This is aggregate demand, not GPU job or grid adequacy simulation.',
+  },
+  {
+    id: 'recovery-deadline',
+    title: '11. Catch a sub-second service gap',
+    concept: 'Exact event timing',
+    question: 'Does 57 kWh bridge recovery at 500 seconds? Does 58 kWh?',
+    preset: 'generator_failure',
+    label: 'Initial battery',
+    unit: 'kWh',
+    initial: '57',
+    challenge: '58',
+    min: 50,
+    max: 65,
+    step: 1,
+    field: 'battery_initial_kwh',
+    resultKey: 'unserved_duration_s',
+    resultUnit: 's unserved',
+    explanation:
+      '57 kWh depletes at 499.8135 s, leaving a 0.1865 s gap before recovery. 58 kWh bridges the outage. The engine resolves the event inside its nominal 10 s step.',
+  },
+  {
+    id: 'pue',
+    title: '12. Separate PUE from continuity',
+    concept: 'Facility energy planning',
+    question: 'How does assumed PUE change annual energy for the same 50 MW IT load?',
+    preset: 'normal',
+    label: 'Assumed PUE',
+    unit: 'ratio',
+    initial: '1.25',
+    challenge: '1.15',
+    min: 1,
+    max: 2,
+    step: 0.05,
+    field: 'pue',
+    resultKey: 'facility_energy_kwh',
+    resultUnit: 'kWh per 8,760 h',
+    explanation:
+      '50,000 × 8,760 × 1.25 = 547,500,000 kWh; at 1.15 it is 503,700,000 kWh. The difference is 43,800,000 kWh at identical IT demand. PUE already includes non-IT overhead: do not add continuity losses to it again.',
+  },
+];
+
+export function lessonScenario(lesson: Lesson, base: SiteScenario, value: string): SiteScenario {
+  const parsed = Number(value);
+  if (!value.trim() || !Number.isFinite(parsed) || parsed < lesson.min || parsed > lesson.max)
+    throw new Error(`${lesson.label}: enter a value from ${lesson.min} to ${lesson.max}`);
+  if (lesson.step >= 1 && !Number.isInteger(parsed)) throw new Error('Enter a whole number.');
+  const scenario = structuredClone(base);
+  scenario.id = `course-${lesson.id}`;
+  scenario.name = lesson.title;
+  scenario.source_ids = [...new Set([...scenario.source_ids, 'EDU-POWER-001'])];
+  if (lesson.id === 'ride-through') scenario.battery_charge_kw = '0';
+  if (lesson.id === 'precharge') scenario.battery_initial_kwh = '50';
+  if (lesson.id === 'recovery-deadline')
+    scenario.events = scenario.events.map((event) =>
+      event.target === 'utility' && event.action === 'asset_up' ? { ...event, at_s: 500 } : event,
+    );
+  switch (lesson.field) {
+    case 'generator_available':
+      if (parsed === 1)
+        scenario.events = scenario.events.filter((event) => event.target !== 'generator');
+      break;
+    case 'path_capacity':
+      scenario.assets = scenario.assets.map((asset) =>
+        asset.kind === 'distribution' ? { ...asset, capacity_kw: value } : asset,
+      );
+      break;
+    case 'shared_controls':
+      if (parsed === 0)
+        scenario.assets = scenario.assets.map((asset) =>
+          asset.id === 'path-b'
+            ? {
+                ...asset,
+                failure_domains: asset.failure_domains.filter(
+                  (domain) => domain !== 'shared-controls',
+                ),
+              }
+            : asset,
+        );
+      break;
+    case 'main_bus_available':
+      scenario.events =
+        parsed === 0
+          ? [
+              { at_s: 300, action: 'asset_down', target: 'main-bus', value_kw: null },
+              { at_s: 900, action: 'asset_up', target: 'main-bus', value_kw: null },
+            ]
+          : [];
+      break;
+    case 'generator_start_delay_s':
+      scenario.generator_start_delay_s = parsed;
+      break;
+    case 'pue':
+      break;
+    default:
+      Object.assign(scenario, { [lesson.field]: value });
+  }
+  return scenario;
+}

--- a/apps/web/src/javascript-worker.ts
+++ b/apps/web/src/javascript-worker.ts
@@ -1,0 +1,153 @@
+import {
+  ENGINE_VERSION,
+  normalizeQuote,
+  renderHtml,
+  renderMarkdown,
+  simulateContinuitySync,
+  simulatePlanning,
+  sweepContinuity,
+} from './js-engine/index';
+import type { Catalog, DemoData } from './js-engine/index';
+import { InputError } from './js-engine/index';
+
+const MAX_REQUEST_BYTES = 4 * 1024 * 1024;
+export type Assets = { demoData?: DemoData; catalog?: Catalog };
+let assetsPromise: Promise<Assets> | undefined;
+let catalogPromise: Promise<Catalog> | undefined;
+
+function pathParts(path: string): URL {
+  const value = path.startsWith('/') ? path : `/${path}`;
+  const normalized = value.replace(/^\/api\/v1\//, '/');
+  return new URL(normalized, 'https://datacenter-twin.invalid');
+}
+
+async function fetchJson(url: URL): Promise<any> {
+  const response = await fetch(url);
+  if (!response.ok)
+    throw new Error(`Browser asset request failed (${response.status}) for ${url.pathname}`);
+  return response.json();
+}
+
+async function loadDemoData(): Promise<DemoData> {
+  const base = new URL(import.meta.env.BASE_URL, self.location.origin);
+  const demoData = await fetchJson(new URL('demo-data.json', base));
+  if (
+    !demoData ||
+    demoData.engine_version !== ENGINE_VERSION ||
+    !Array.isArray(demoData.presets) ||
+    !demoData.scenarios
+  )
+    throw new Error(`Demo data engine version mismatch; expected ${ENGINE_VERSION}`);
+  return demoData;
+}
+
+async function loadCatalog(): Promise<Catalog> {
+  const base = new URL(import.meta.env.BASE_URL, self.location.origin);
+  return fetchJson(new URL('catalog.json', base));
+}
+
+async function resourcesFor(route: URL): Promise<Assets> {
+  if (route.pathname === '/catalog' || route.pathname === '/quotes/normalize') {
+    catalogPromise ??= loadCatalog().catch((error) => {
+      catalogPromise = undefined;
+      throw error;
+    });
+    return { catalog: await catalogPromise };
+  }
+  assetsPromise ??= loadDemoData()
+    .then((demoData) => ({ demoData }))
+    .catch((error) => {
+      assetsPromise = undefined;
+      throw error;
+    });
+  return assetsPromise;
+}
+
+function validateBodyKeys(payload: unknown, keys: string[], message: string): Record<string, any> {
+  if (payload === null || typeof payload !== 'object' || Array.isArray(payload))
+    throw new InputError(message);
+  const data = payload as Record<string, any>;
+  const expected = new Set(keys);
+  if (
+    Object.keys(data).some((key) => !expected.has(key)) ||
+    keys.some((key) => !Object.prototype.hasOwnProperty.call(data, key))
+  )
+    throw new InputError(message);
+  return data;
+}
+
+export function dispatchParsed(path: string, payload: unknown, assets: Assets): unknown {
+  const route = pathParts(path);
+  if (route.pathname === '/presets') {
+    if (!assets.demoData) throw new Error('Demo data is not loaded');
+    return assets.demoData.presets;
+  }
+  if (route.pathname === '/demo') {
+    if (!assets.demoData) throw new Error('Demo data is not loaded');
+    const preset = route.searchParams.get('preset') || 'utility_loss';
+    const scenario = assets.demoData.scenarios[preset];
+    if (!scenario) throw new InputError('Unknown demo preset');
+    return scenario;
+  }
+  if (route.pathname === '/catalog') {
+    if (!assets.catalog) throw new Error('Catalog is not loaded');
+    return assets.catalog;
+  }
+  if (route.pathname === '/simulations') return simulateContinuitySync(payload);
+  if (route.pathname === '/planning') return simulatePlanning(payload);
+  if (route.pathname === '/quotes/normalize') {
+    if (!assets.catalog) throw new Error('Catalog is not loaded');
+    return normalizeQuote(payload, assets.catalog);
+  }
+  if (route.pathname === '/sweeps') {
+    const data = validateBodyKeys(
+      payload,
+      ['scenario', 'parameter', 'values'],
+      'Sweep requires scenario, parameter, and values',
+    );
+    return sweepContinuity(data.scenario, data.parameter, data.values);
+  }
+  if (route.pathname === '/reports') {
+    const data = validateBodyKeys(
+      payload,
+      ['scenario', 'format'],
+      'Report requires scenario and format',
+    );
+    if (data.format !== 'markdown' && data.format !== 'html')
+      throw new InputError('Report format must be markdown or html');
+    const run = simulateContinuitySync(data.scenario);
+    return {
+      format: data.format,
+      text: data.format === 'html' ? renderHtml(run) : renderMarkdown(run),
+      run_id: run.run_id,
+    };
+  }
+  throw new InputError('Unsupported browser operation');
+}
+
+export async function dispatchJson(path: string, body = 'null', assets?: Assets): Promise<unknown> {
+  if (typeof body !== 'string') throw new InputError('Request body must be JSON text');
+  if (new TextEncoder().encode(body).byteLength > MAX_REQUEST_BYTES)
+    throw new InputError('Request exceeds the 4 MiB input limit');
+  const payload = JSON.parse(body);
+  const resources = assets ?? (await resourcesFor(pathParts(path)));
+  return dispatchParsed(path, payload, resources);
+}
+
+if (typeof self !== 'undefined') {
+  let queue = Promise.resolve();
+  self.addEventListener(
+    'message',
+    (event: MessageEvent<{ id: number; path: string; body: string }>) => {
+      const { id, path, body } = event.data;
+      queue = queue.then(async () => {
+        try {
+          const result = await dispatchJson(path, body);
+          self.postMessage({ id, result });
+        } catch (error) {
+          self.postMessage({ id, error: error instanceof Error ? error.message : String(error) });
+        }
+      });
+    },
+  );
+}

--- a/apps/web/src/js-engine/canonical.ts
+++ b/apps/web/src/js-engine/canonical.ts
@@ -1,0 +1,133 @@
+import type { JsonValue } from './types';
+
+// Browser builds already provide TextEncoder.  The declaration keeps the
+// implementation usable in Node's native TypeScript runner as well.
+const encoder: { encode(value: string): Uint8Array } = new globalThis.TextEncoder();
+
+/** Compare strings by Unicode code point, like Python's `str` ordering. */
+export function compareUnicode(left: string, right: string): number {
+  let leftIndex = 0;
+  let rightIndex = 0;
+  while (leftIndex < left.length && rightIndex < right.length) {
+    const leftCode = left.codePointAt(leftIndex)!;
+    const rightCode = right.codePointAt(rightIndex)!;
+    if (leftCode < rightCode) return -1;
+    if (leftCode > rightCode) return 1;
+    leftIndex += leftCode > 0xffff ? 2 : 1;
+    rightIndex += rightCode > 0xffff ? 2 : 1;
+  }
+  return left.length - leftIndex - (right.length - rightIndex);
+}
+
+function quote(value: string): string {
+  let result = '"';
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index);
+    if (code === 0x08) result += '\\b';
+    else if (code === 0x09) result += '\\t';
+    else if (code === 0x0a) result += '\\n';
+    else if (code === 0x0c) result += '\\f';
+    else if (code === 0x0d) result += '\\r';
+    else if (code === 0x22) result += '\\"';
+    else if (code === 0x5c) result += '\\\\';
+    else if (code < 0x20 || code >= 0x80) result += `\\u${code.toString(16).padStart(4, '0')}`;
+    else result += value[index];
+  }
+  return `${result}"`;
+}
+
+/** json.dumps(value, sort_keys=True, separators=(',', ':')) with ensure_ascii. */
+export function canonicalJson(value: JsonValue): string {
+  if (value === null) return 'null';
+  if (typeof value === 'string') return quote(value);
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new Error('Cannot canonicalize a non-finite number');
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (Array.isArray(value)) return `[${value.map((item) => canonicalJson(item)).join(',')}]`;
+  const keys = Object.keys(value).sort(compareUnicode);
+  return `{${keys.map((key) => `${quote(key)}:${canonicalJson(value[key])}`).join(',')}}`;
+}
+
+// SHA-256 is kept local so the engine has no Node-only dependency and works
+// in a Web Worker as well as in a browser tab.
+const K = [
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+];
+
+const rotr = (value: number, count: number) => (value >>> count) | (value << (32 - count));
+const add = (...values: number[]) => values.reduce((sum, value) => (sum + value) >>> 0, 0);
+
+export function sha256Hex(value: string): string {
+  const source = encoder.encode(value);
+  const bitLength = source.length * 8;
+  const paddedLength = ((source.length + 9 + 63) >> 6) << 6;
+  const bytes = new Uint8Array(paddedLength);
+  bytes.set(source);
+  bytes[source.length] = 0x80;
+  const view = new DataView(bytes.buffer);
+  view.setUint32(paddedLength - 4, bitLength >>> 0);
+  view.setUint32(paddedLength - 8, Math.floor(bitLength / 0x100000000) >>> 0);
+  let h0 = 0x6a09e667;
+  let h1 = 0xbb67ae85;
+  let h2 = 0x3c6ef372;
+  let h3 = 0xa54ff53a;
+  let h4 = 0x510e527f;
+  let h5 = 0x9b05688c;
+  let h6 = 0x1f83d9ab;
+  let h7 = 0x5be0cd19;
+  for (let offset = 0; offset < bytes.length; offset += 64) {
+    const words = new Uint32Array(64);
+    for (let i = 0; i < 16; i++) words[i] = view.getUint32(offset + i * 4);
+    for (let i = 16; i < 64; i++) {
+      const x = words[i - 15];
+      const y = words[i - 2];
+      const small0 = rotr(x, 7) ^ rotr(x, 18) ^ (x >>> 3);
+      const small1 = rotr(y, 17) ^ rotr(y, 19) ^ (y >>> 10);
+      words[i] = add(words[i - 16], small0, words[i - 7], small1);
+    }
+    let a = h0,
+      b = h1,
+      c = h2,
+      d = h3,
+      e = h4,
+      f = h5,
+      g = h6,
+      h = h7;
+    for (let i = 0; i < 64; i++) {
+      const big1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+      const choose = (e & f) ^ (~e & g);
+      const temp1 = add(h, big1, choose, K[i], words[i]);
+      const big0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+      const majority = (a & b) ^ (a & c) ^ (b & c);
+      const temp2 = add(big0, majority);
+      h = g;
+      g = f;
+      f = e;
+      e = add(d, temp1);
+      d = c;
+      c = b;
+      b = a;
+      a = add(temp1, temp2);
+    }
+    h0 = add(h0, a);
+    h1 = add(h1, b);
+    h2 = add(h2, c);
+    h3 = add(h3, d);
+    h4 = add(h4, e);
+    h5 = add(h5, f);
+    h6 = add(h6, g);
+    h7 = add(h7, h);
+  }
+  return [h0, h1, h2, h3, h4, h5, h6, h7]
+    .map((value) => value.toString(16).padStart(8, '0'))
+    .join('');
+}

--- a/apps/web/src/js-engine/continuity.ts
+++ b/apps/web/src/js-engine/continuity.ts
@@ -1,0 +1,407 @@
+import { canonicalJson, compareUnicode, sha256Hex } from './canonical';
+import { decimalText, InputError, moneyText, Rational } from './decimal';
+import { parseQuantity, topologicalOrder, validateScenario } from './contract';
+import type { Asset, Interval, Run, SiteScenario } from './types';
+import { ENGINE_VERSION } from './version';
+
+const MODEL = 'single_load_electrical_continuity_v1' as const;
+const zero = () => Rational.zero();
+const quantity = (value: string | number): Rational =>
+  typeof value === 'number' ? Rational.fromInteger(value) : parseQuantity(value);
+const min = (left: Rational, right: Rational) => (left.compare(right) <= 0 ? left : right);
+const max = (left: Rational, right: Rational) => (left.compare(right) >= 0 ? left : right);
+
+export class FlowNetwork {
+  readonly residual = new Map<string, Map<string, Rational>>();
+  readonly capacity = new Map<string, Rational>();
+
+  private key(source: string, target: string): string {
+    return `${source}\u0000${target}`;
+  }
+
+  add(source: string, target: string, capacity: Rational): void {
+    if (!this.residual.has(source)) this.residual.set(source, new Map());
+    if (!this.residual.has(target)) this.residual.set(target, new Map());
+    this.residual.get(source)!.set(target, capacity);
+    this.residual.get(target)!.set(source, zero());
+    this.capacity.set(this.key(source, target), capacity);
+  }
+
+  flow(source: string, target: string): Rational {
+    return this.capacity
+      .get(this.key(source, target))!
+      .sub(this.residual.get(source)!.get(target)!);
+  }
+
+  augment(): void {
+    while (true) {
+      const parents = new Map<string, string | null>([['SOURCE', null]]);
+      const queue = ['SOURCE'];
+      while (queue.length && !parents.has('SINK')) {
+        const current = queue.shift()!;
+        const edges = Array.from(this.residual.get(current)?.keys() ?? []).sort(compareUnicode);
+        for (const target of edges) {
+          if (!parents.has(target) && this.residual.get(current)!.get(target)!.isPositive()) {
+            parents.set(target, current);
+            queue.push(target);
+          }
+        }
+      }
+      if (!parents.has('SINK')) return;
+      let current = 'SINK';
+      let amount: Rational | null = null;
+      while (parents.get(current) !== null) {
+        const previous = parents.get(current)!;
+        const value = this.residual.get(previous)!.get(current)!;
+        amount = amount === null ? value : min(amount, value);
+        current = previous;
+      }
+      current = 'SINK';
+      while (parents.get(current) !== null) {
+        const previous = parents.get(current)!;
+        const forward = this.residual.get(previous)!.get(current)!;
+        const backward = this.residual.get(current)!.get(previous)!;
+        this.residual.get(previous)!.set(current, forward.sub(amount!));
+        this.residual.get(current)!.set(previous, backward.add(amount!));
+        current = previous;
+      }
+    }
+  }
+}
+
+const limitations = [
+  'No switching transient, protection study, cooling, workload queue or certification model.',
+  'Generator starts on utility-asset unavailability only; downstream path faults do not request a start.',
+  'Generator fuel is assumed sufficient for this horizon; its unit energy cost may be unknown.',
+  'Initial stored battery energy is an opening balance; prior charging cost is excluded.',
+  'Prices are illustrative inputs; costs exclude CAPEX and non-energy charges.',
+];
+
+function text(value: Rational): string {
+  return decimalText(value);
+}
+
+function eventValue(event: SiteScenario['events'][number]): Record<string, string | number | null> {
+  return { at_s: event.at_s, action: event.action, target: event.target, value_kw: event.value_kw };
+}
+
+/** Synchronous implementation used by the public async API and differential tests. */
+export function simulateValidated(scenario: SiteScenario): Run {
+  const canonical = canonicalJson(scenario as never);
+  const digest = sha256Hex(canonical);
+  const runId = sha256Hex(`continuity-v1:${ENGINE_VERSION}:${digest}`).slice(0, 20);
+  const assets = new Map(scenario.assets.map((asset) => [asset.id, asset]));
+  const utility = scenario.assets.find((asset) => asset.kind === 'utility')!.id;
+  const generator = scenario.assets.find((asset) => asset.kind === 'generator')!.id;
+  const battery = scenario.assets.find((asset) => asset.kind === 'battery')!.id;
+  const load = scenario.assets.find((asset) => asset.kind === 'load')!.id;
+  const requiresOrder = topologicalOrder(scenario, 'requires');
+  const incomingRequires = new Map<string, string[]>(
+    scenario.assets.map((asset) => [asset.id, []]),
+  );
+  for (const edge of scenario.dependencies)
+    if (edge.relation === 'requires') incomingRequires.get(edge.target)!.push(edge.source);
+  const schedule = scenario.events
+    .map((event, index) => ({ event, index }))
+    .sort((left, right) => left.event.at_s - right.event.at_s || left.index - right.index);
+  const directDown = new Set<string>();
+  const domainsDown = new Set<string>();
+  let eventIndex = 0;
+  let now = zero();
+  let demand = quantity(scenario.it_demand_kw);
+  let energy = quantity(scenario.battery_initial_kwh);
+  const capacity = quantity(scenario.battery_capacity_kwh);
+  const eta = quantity(scenario.distribution_efficiency);
+  const chargeEta = quantity(scenario.battery_charge_efficiency);
+  const dischargeEta = quantity(scenario.battery_discharge_efficiency);
+  let readyAt: Rational | null = null;
+  const rows: Interval[] = [];
+  const log: Record<string, unknown>[] = [];
+  const totalKeys = [
+    'requested_it_kwh',
+    'served_it_kwh',
+    'unserved_it_kwh',
+    'grid_kwh',
+    'generator_kwh',
+    'distribution_loss_kwh',
+    'battery_charge_loss_kwh',
+    'battery_discharge_loss_kwh',
+    'battery_stored_change_kwh',
+    'unserved_duration_s',
+  ];
+  const totals = new Map(totalKeys.map((key) => [key, zero()]));
+  let peakUnserved = zero();
+  while (now.compare(Rational.fromInteger(scenario.duration_s)) < 0) {
+    if (rows.length > 5000) throw new InputError('Simulation exceeded its interval budget');
+    while (
+      eventIndex < schedule.length &&
+      now.compare(Rational.fromInteger(schedule[eventIndex].event.at_s)) === 0
+    ) {
+      const scheduled = schedule[eventIndex];
+      const current = scheduled.event;
+      if (current.action === 'asset_down') directDown.add(current.target);
+      else if (current.action === 'asset_up') directDown.delete(current.target);
+      else if (current.action === 'domain_down') domainsDown.add(current.target);
+      else if (current.action === 'domain_up') domainsDown.delete(current.target);
+      else demand = quantity(current.value_kw!);
+      log.push({
+        ...eventValue(current),
+        at_s: text(Rational.fromInteger(current.at_s)),
+        sequence: scheduled.index,
+        origin: 'scenario_event',
+      });
+      eventIndex += 1;
+    }
+    const available = new Map<string, boolean>();
+    for (const id of requiresOrder) {
+      const asset = assets.get(id)!;
+      const okay =
+        !directDown.has(id) &&
+        !asset.failure_domains.some((domain) => domainsDown.has(domain)) &&
+        incomingRequires.get(id)!.every((source) => available.get(source));
+      available.set(id, okay);
+    }
+    if (available.get(utility) || !available.get(generator)) {
+      readyAt = null;
+    } else if (readyAt === null) {
+      readyAt = now.add(Rational.fromInteger(scenario.generator_start_delay_s));
+      log.push({
+        at_s: text(now),
+        action: 'generator_start_requested',
+        target: generator,
+        ready_at_s: text(readyAt),
+        origin: 'simulation',
+      });
+    }
+    const running = readyAt !== null && now.compare(readyAt) >= 0 && available.get(generator);
+    let boundary = min(
+      now.add(Rational.fromInteger(scenario.step_s)),
+      Rational.fromInteger(scenario.duration_s),
+    );
+    if (eventIndex < schedule.length)
+      boundary = min(boundary, Rational.fromInteger(schedule[eventIndex].event.at_s));
+    if (readyAt !== null && readyAt.compare(now) > 0) boundary = min(boundary, readyAt);
+
+    const network = new FlowNetwork();
+    const infinity = scenario.assets.reduce(
+      (total, asset) => total.add(quantity(asset.capacity_kw)),
+      zero(),
+    );
+    for (const id of Array.from(assets.keys()).sort(compareUnicode))
+      network.add(
+        `in:${id}`,
+        `out:${id}`,
+        available.get(id) ? quantity(assets.get(id)!.capacity_kw) : zero(),
+      );
+    for (const edge of scenario.dependencies
+      .slice()
+      .sort(
+        (left, right) =>
+          compareUnicode(left.source, right.source) ||
+          compareUnicode(left.target, right.target) ||
+          compareUnicode(left.relation, right.relation),
+      ))
+      if (edge.relation === 'feeds')
+        network.add(`out:${edge.source}`, `in:${edge.target}`, infinity);
+    network.add(`out:${load}`, 'SINK', demand.div(eta));
+    for (const [source, enabled] of [
+      [utility, available.get(utility)],
+      [generator, running],
+      [battery, energy.isPositive() && available.get(battery)],
+    ] as [string, boolean | undefined][]) {
+      network.add(
+        'SOURCE',
+        `in:${source}`,
+        enabled ? quantity(assets.get(source)!.capacity_kw) : zero(),
+      );
+      network.augment();
+    }
+    const grossLoad = network.flow(`out:${load}`, 'SINK');
+    const batteryKw = network.flow('SOURCE', `in:${battery}`);
+    const generatorKw = network.flow('SOURCE', `in:${generator}`);
+    let chargingKw = zero();
+    if (
+      batteryKw.isZero() &&
+      generatorKw.isZero() &&
+      available.get(utility) &&
+      available.get(battery) &&
+      energy.compare(capacity) < 0
+    ) {
+      for (const source of [generator, battery]) {
+        network.residual.get('SOURCE')!.set(`in:${source}`, zero());
+        network.capacity.set(`SOURCE\u0000in:${source}`, zero());
+      }
+      const chargingEdge = scenario.dependencies.find((edge) => edge.relation === 'charges')!;
+      network.add(`out:${chargingEdge.source}`, 'CHARGER', quantity(scenario.battery_charge_kw));
+      network.add('CHARGER', 'SINK', quantity(scenario.battery_charge_kw));
+      network.augment();
+      chargingKw = network.flow('CHARGER', 'SINK');
+    }
+    const gridKw = network.flow('SOURCE', `in:${utility}`);
+    if (batteryKw.isPositive())
+      boundary = min(
+        boundary,
+        now.add(energy.mul(dischargeEta).div(batteryKw).mul(Rational.fromInteger(3600))),
+      );
+    if (chargingKw.isPositive())
+      boundary = min(
+        boundary,
+        now.add(
+          capacity.sub(energy).div(chargingKw.mul(chargeEta)).mul(Rational.fromInteger(3600)),
+        ),
+      );
+    const seconds = boundary.sub(now);
+    if (seconds.compare(zero()) <= 0) throw new Error('Non-progressing simulation boundary');
+    const hours = seconds.div(Rational.fromInteger(3600));
+    const previousEnergy = energy;
+    const batteryOut = batteryKw.mul(hours).div(dischargeEta);
+    const batteryIn = chargingKw.mul(hours).mul(chargeEta);
+    energy = energy.sub(batteryOut).add(batteryIn);
+    const served = grossLoad.mul(eta);
+    const unserved = demand.sub(served);
+    const values = new Map<string, Rational>([
+      ['requested_it_kwh', demand.mul(hours)],
+      ['served_it_kwh', served.mul(hours)],
+      ['unserved_it_kwh', unserved.mul(hours)],
+      ['grid_kwh', gridKw.mul(hours)],
+      ['generator_kwh', generatorKw.mul(hours)],
+      ['distribution_loss_kwh', grossLoad.sub(served).mul(hours)],
+      ['battery_charge_loss_kwh', chargingKw.mul(hours).sub(batteryIn)],
+      ['battery_discharge_loss_kwh', batteryOut.sub(batteryKw.mul(hours))],
+      ['battery_stored_change_kwh', energy.sub(previousEnergy)],
+      ['unserved_duration_s', unserved.isPositive() ? seconds : zero()],
+    ]);
+    const residual = values
+      .get('grid_kwh')!
+      .add(values.get('generator_kwh')!)
+      .sub(values.get('battery_stored_change_kwh')!)
+      .sub(values.get('served_it_kwh')!)
+      .sub(values.get('distribution_loss_kwh')!)
+      .sub(values.get('battery_charge_loss_kwh')!)
+      .sub(values.get('battery_discharge_loss_kwh')!);
+    if (
+      !residual.isZero() ||
+      energy.compare(zero()) < 0 ||
+      energy.compare(capacity) > 0 ||
+      unserved.compare(zero()) < 0
+    )
+      throw new Error('Electrical energy invariant violated');
+    for (const [key, value] of values) totals.set(key, totals.get(key)!.add(value));
+    peakUnserved = max(peakUnserved, unserved);
+    const warnings: string[] = [];
+    if (unserved.isPositive()) warnings.push('UNSERVED_IT_LOAD');
+    if (demand.compare(quantity(scenario.it_capacity_kw)) > 0)
+      warnings.push('IT_ENVELOPE_EXCEEDED');
+    if (!available.get(utility)) warnings.push('UTILITY_UNAVAILABLE');
+    if (energy.isZero()) warnings.push('BATTERY_EMPTY');
+    if (domainsDown.size) warnings.push('SHARED_DOMAIN_OUTAGE');
+    const assetStates: Record<string, string> = {};
+    for (const asset of scenario.assets)
+      assetStates[asset.id] = available.get(asset.id) ? 'available' : 'unavailable';
+    if (available.get(generator))
+      assetStates[generator] = running ? 'running' : readyAt !== null ? 'starting' : 'standby';
+    if (available.get(battery))
+      assetStates[battery] = batteryKw.isPositive()
+        ? 'discharging'
+        : chargingKw.isPositive()
+          ? 'charging'
+          : energy.isZero()
+            ? 'empty'
+            : 'ready';
+    if (available.get(load))
+      assetStates[load] =
+        served.isZero() && demand.isPositive()
+          ? 'unserved'
+          : unserved.isPositive()
+            ? 'degraded'
+            : 'served';
+    const energyObject: Record<string, string> = {};
+    for (const [key, value] of values) energyObject[key] = text(value);
+    const tariff = scenario.tariff_per_kwh === null ? null : quantity(scenario.tariff_per_kwh);
+    rows.push({
+      start_s: text(now),
+      end_s: text(boundary),
+      duration_s: text(seconds),
+      requested_it_kw: text(demand),
+      served_it_kw: text(served),
+      unserved_it_kw: text(unserved),
+      electrical_source_kw: text(gridKw.add(generatorKw).add(batteryKw)),
+      grid_kw: text(gridKw),
+      generator_kw: text(generatorKw),
+      battery_discharge_kw: text(batteryKw),
+      battery_charge_kw: text(chargingKw),
+      battery_start_kwh: text(previousEnergy),
+      battery_end_kwh: text(energy),
+      it_capacity_margin_kw: text(quantity(scenario.it_capacity_kw).sub(demand)),
+      grid_energy_charge_to_date:
+        tariff === null ? null : moneyText(totals.get('grid_kwh')!.mul(tariff)),
+      energy: energyObject,
+      energy_balance_residual_kwh: '0',
+      asset_states: assetStates,
+      warnings,
+      feed_flows_kw: scenario.dependencies
+        .filter((edge) => edge.relation === 'feeds')
+        .map((edge) => ({
+          source: edge.source,
+          target: edge.target,
+          kw: text(network.flow(`out:${edge.source}`, `in:${edge.target}`)),
+        })),
+    });
+    if (energy.isZero() && previousEnergy.isPositive())
+      log.push({
+        at_s: text(boundary),
+        action: 'battery_depleted',
+        target: battery,
+        origin: 'simulation',
+      });
+    now = boundary;
+  }
+  const gridCost =
+    scenario.tariff_per_kwh === null
+      ? null
+      : totals.get('grid_kwh')!.mul(quantity(scenario.tariff_per_kwh));
+  const generatorCost = totals.get('generator_kwh')!.isZero()
+    ? zero()
+    : scenario.generator_cost_per_kwh === null
+      ? null
+      : totals.get('generator_kwh')!.mul(quantity(scenario.generator_cost_per_kwh));
+  const summary: Record<string, unknown> = {};
+  for (const key of totalKeys) summary[key] = text(totals.get(key)!);
+  summary.battery_final_kwh = text(energy);
+  summary.peak_unserved_kw = text(peakUnserved);
+  summary.energy_balance_residual_kwh = '0';
+  summary.grid_energy_charge = moneyText(gridCost);
+  summary.generator_energy_charge = moneyText(generatorCost);
+  summary.total_incremental_energy_charge =
+    gridCost === null || generatorCost === null ? null : moneyText(gridCost.add(generatorCost));
+  summary.cost_status =
+    gridCost === null || generatorCost === null ? 'unknown_component' : 'illustrative';
+  summary.service_status = totals.get('unserved_it_kwh')!.isPositive()
+    ? 'unserved_load'
+    : 'served_throughout';
+  summary.interval_count = rows.length;
+  return {
+    schema_version: 2,
+    model: MODEL,
+    engine_version: ENGINE_VERSION,
+    run_id: runId,
+    input_sha256: digest,
+    mode: 'SIMULATED',
+    quality: 'synthetic_uncalibrated',
+    scenario,
+    intervals: rows,
+    events: log as Record<string, never>[],
+    summary: summary as Run['summary'],
+    boundary:
+      'Electrical supply, stored battery energy, conversion losses and served IT; cooling excluded',
+    limitations,
+  };
+}
+
+export async function simulateContinuity(input: unknown): Promise<Run> {
+  return simulateValidated(validateScenario(input));
+}
+
+export function simulateContinuitySync(input: unknown): Run {
+  return simulateValidated(validateScenario(input));
+}

--- a/apps/web/src/js-engine/contract.ts
+++ b/apps/web/src/js-engine/contract.ts
@@ -1,0 +1,305 @@
+import { compareUnicode } from './canonical';
+import { decimalText, InputError, Rational } from './decimal';
+import type { Asset, Dependency, ScenarioEvent, SiteScenario } from './types';
+
+type RecordValue = { [key: string]: unknown };
+
+function object(value: unknown, name: string): RecordValue {
+  if (value === null || typeof value !== 'object' || Array.isArray(value))
+    throw new InputError(`${name}: expected an object`);
+  return value as RecordValue;
+}
+
+function exactKeys(value: RecordValue, required: string[], name: string): void {
+  const expected = new Set(required);
+  const actual = Object.keys(value);
+  const missing = required.filter((key) => !Object.prototype.hasOwnProperty.call(value, key));
+  const extra = actual.filter((key) => !expected.has(key));
+  if (missing.length || extra.length)
+    throw new InputError(
+      `${name}: missing fields [${missing.join(', ')}]; unknown fields [${extra.join(', ')}]`,
+    );
+}
+
+function text(value: unknown, name: string): string {
+  if (typeof value !== 'string' || !value.trim() || Array.from(value).length > 200)
+    throw new InputError(`${name}: expected nonempty text of at most 200 characters`);
+  return value;
+}
+
+function decimal(value: unknown, name: string, positive = false): Rational {
+  return Rational.fromDecimal(value, name, { positive });
+}
+
+function integer(value: unknown, name: string, low: number, high: number): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < low || value > high)
+    throw new InputError(`${name}: expected an integer from ${low} to ${high}`);
+  return value;
+}
+
+function stringList(value: unknown, name: string, nonempty = true): string[] {
+  if (!Array.isArray(value) || value.length > 100 || (nonempty && value.length === 0))
+    throw new InputError(`${name}: expected ${nonempty ? '1' : '0'} to 100 identifiers`);
+  const result = value.map((item) => text(item, name));
+  if (new Set(result).size !== result.length)
+    throw new InputError(`${name}: duplicate identifiers`);
+  return result;
+}
+
+function asset(value: unknown): Asset {
+  const data = object(value, 'asset');
+  exactKeys(data, ['id', 'name', 'kind', 'capacity_kw', 'failure_domains', 'source_ids'], 'asset');
+  const kind = data.kind;
+  if (!['utility', 'generator', 'battery', 'bus', 'distribution', 'load'].includes(String(kind)))
+    throw new InputError('asset.kind: unsupported asset type');
+  return {
+    id: text(data.id, 'asset.id'),
+    name: text(data.name, 'asset.name'),
+    kind: kind as string,
+    capacity_kw: decimalText(decimal(data.capacity_kw, 'capacity_kw', true)),
+    failure_domains: stringList(data.failure_domains, 'failure_domains'),
+    source_ids: stringList(data.source_ids, 'source_ids'),
+  };
+}
+
+function dependency(value: unknown): Dependency {
+  const data = object(value, 'dependency');
+  exactKeys(data, ['source', 'target', 'relation'], 'dependency');
+  const source = text(data.source, 'dependency.source');
+  const target = text(data.target, 'dependency.target');
+  const relation = data.relation;
+  if (source === target || !['feeds', 'requires', 'charges'].includes(String(relation)))
+    throw new InputError(
+      'dependency: distinct endpoints and feeds/requires/charges relation required',
+    );
+  return { source, target, relation: relation as string };
+}
+
+function event(value: unknown): ScenarioEvent {
+  const data = object(value, 'event');
+  exactKeys(data, ['at_s', 'action', 'target', 'value_kw'], 'event');
+  const at_s = integer(data.at_s, 'event.at_s', 0, 86400);
+  const action = data.action;
+  if (
+    typeof action !== 'string' ||
+    !['asset_down', 'asset_up', 'domain_down', 'domain_up', 'set_demand'].includes(action)
+  )
+    throw new InputError('event.action: unsupported simulated event');
+  const target = text(data.target, 'event.target');
+  if (action === 'set_demand')
+    return {
+      at_s,
+      action,
+      target,
+      value_kw: decimalText(decimal(data.value_kw, 'event.value_kw')),
+    };
+  if (data.value_kw !== null)
+    throw new InputError('event.value_kw: must be null for availability events');
+  return { at_s, action, target, value_kw: null };
+}
+
+function topo(scenarioAssets: Asset[], dependencies: Dependency[], relation: string): string[] {
+  const ids = new Set(scenarioAssets.map((item) => item.id));
+  const incoming = new Map<string, number>(Array.from(ids, (id) => [id, 0]));
+  const outgoing = new Map<string, string[]>(Array.from(ids, (id) => [id, []]));
+  for (const edge of dependencies) {
+    if (edge.relation !== relation) continue;
+    incoming.set(edge.target, incoming.get(edge.target)! + 1);
+    outgoing.get(edge.source)!.push(edge.target);
+  }
+  const queue = Array.from(ids)
+    .filter((id) => incoming.get(id) === 0)
+    .sort(compareUnicode);
+  const result: string[] = [];
+  while (queue.length) {
+    const current = queue.shift()!;
+    result.push(current);
+    for (const target of outgoing.get(current)!.slice().sort(compareUnicode)) {
+      const count = incoming.get(target)! - 1;
+      incoming.set(target, count);
+      if (count === 0) {
+        queue.push(target);
+        queue.sort(compareUnicode);
+      }
+    }
+  }
+  if (result.length !== ids.size) throw new InputError(`Topology contains a ${relation} cycle`);
+  return result;
+}
+
+const scenarioFields = [
+  'schema_version',
+  'id',
+  'name',
+  'currency',
+  'duration_s',
+  'step_s',
+  'it_demand_kw',
+  'it_capacity_kw',
+  'distribution_efficiency',
+  'tariff_per_kwh',
+  'generator_cost_per_kwh',
+  'generator_start_delay_s',
+  'battery_capacity_kwh',
+  'battery_initial_kwh',
+  'battery_charge_kw',
+  'battery_charge_efficiency',
+  'battery_discharge_efficiency',
+  'source_ids',
+  'assets',
+  'dependencies',
+  'events',
+];
+
+/** Validate and canonicalize a schema-2 scenario for simulation. */
+export function validateScenario(input: unknown): SiteScenario {
+  const data = object(input, 'continuity scenario');
+  exactKeys(data, scenarioFields, 'continuity scenario');
+  if (data.schema_version !== 2 || typeof data.schema_version !== 'number')
+    throw new InputError('schema_version: only integer 2 is supported');
+  const currency = data.currency;
+  if (currency !== 'USD' && currency !== 'EUR' && currency !== 'INR')
+    throw new InputError('currency: expected USD, EUR or INR; no FX conversion');
+  const duration_s = integer(data.duration_s, 'duration_s', 1, 86400);
+  const step_s = integer(data.step_s, 'step_s', 1, 3600);
+  if (duration_s > step_s * 2000)
+    throw new InputError('Requested time resolution exceeds 2000 regular intervals');
+  const generator_start_delay_s = integer(
+    data.generator_start_delay_s,
+    'generator_start_delay_s',
+    0,
+    86400,
+  );
+  const it_demand = decimal(data.it_demand_kw, 'it_demand_kw');
+  const it_capacity = decimal(data.it_capacity_kw, 'it_capacity_kw', true);
+  const distribution = decimal(data.distribution_efficiency, 'distribution_efficiency', true);
+  const chargeEfficiency = decimal(
+    data.battery_charge_efficiency,
+    'battery_charge_efficiency',
+    true,
+  );
+  const dischargeEfficiency = decimal(
+    data.battery_discharge_efficiency,
+    'battery_discharge_efficiency',
+    true,
+  );
+  const efficiencies: [string, Rational][] = [
+    ['distribution_efficiency', distribution],
+    ['battery_charge_efficiency', chargeEfficiency],
+    ['battery_discharge_efficiency', dischargeEfficiency],
+  ];
+  for (const [name, value] of efficiencies) {
+    if (value.compare(Rational.one()) > 0)
+      throw new InputError(`${name}: expected an efficiency in (0, 1]`);
+  }
+  const tariff =
+    data.tariff_per_kwh === null ? null : decimal(data.tariff_per_kwh, 'tariff_per_kwh');
+  const generatorCost =
+    data.generator_cost_per_kwh === null
+      ? null
+      : decimal(data.generator_cost_per_kwh, 'generator_cost_per_kwh');
+  const batteryCapacity = decimal(data.battery_capacity_kwh, 'battery_capacity_kwh', true);
+  const batteryInitial = decimal(data.battery_initial_kwh, 'battery_initial_kwh');
+  const batteryCharge = decimal(data.battery_charge_kw, 'battery_charge_kw');
+  if (batteryInitial.compare(batteryCapacity) > 0)
+    throw new InputError('battery_initial_kwh exceeds stored-energy capacity');
+  const source_ids = stringList(data.source_ids, 'source_ids');
+  if (!Array.isArray(data.assets) || data.assets.length > 64)
+    throw new InputError('assets: expected a bounded JSON array');
+  if (!Array.isArray(data.dependencies) || data.dependencies.length > 256)
+    throw new InputError('dependencies: expected a bounded JSON array');
+  if (!Array.isArray(data.events) || data.events.length > 128)
+    throw new InputError('events: expected a bounded JSON array');
+  const assets = data.assets.map(asset);
+  const dependencies = data.dependencies.map(dependency);
+  const events = data.events.map(event);
+  const byId = new Map(assets.map((item) => [item.id, item]));
+  if (byId.size !== assets.length) throw new InputError('Asset identifiers must be unique');
+  for (const kind of ['utility', 'generator', 'battery', 'load']) {
+    if (assets.filter((item) => item.kind === kind).length !== 1)
+      throw new InputError(`This model requires exactly one ${kind} asset`);
+  }
+  const batteryAsset = assets.find((item) => item.kind === 'battery')!;
+  if (batteryCharge.compare(Rational.fromDecimal(batteryAsset.capacity_kw)) > 0)
+    throw new InputError('battery_charge_kw exceeds the battery electrical power rating');
+  const domains = new Set(assets.flatMap((item) => item.failure_domains));
+  const seen = new Set<string>();
+  for (const edge of dependencies) {
+    if (!byId.has(edge.source) || !byId.has(edge.target))
+      throw new InputError('Dependency refers to a missing asset');
+    const key = `${edge.source}\u0000${edge.target}\u0000${edge.relation}`;
+    if (seen.has(key)) throw new InputError('Duplicate dependency');
+    seen.add(key);
+    if (
+      edge.relation === 'feeds' &&
+      (['utility', 'generator', 'battery'].includes(byId.get(edge.target)!.kind) ||
+        byId.get(edge.source)!.kind === 'load')
+    )
+      throw new InputError('Feeds must lead from sources toward the load');
+    if (
+      edge.relation === 'charges' &&
+      (byId.get(edge.target)!.kind !== 'battery' || byId.get(edge.source)!.kind !== 'bus')
+    )
+      throw new InputError('Charging connections must lead from a bus to the battery');
+  }
+  if (dependencies.filter((edge) => edge.relation === 'charges').length !== 1)
+    throw new InputError('Provide exactly one explicit bus-to-battery charging connection');
+  topo(assets, dependencies, 'feeds');
+  topo(assets, dependencies, 'requires');
+  const load = assets.find((item) => item.kind === 'load')!.id;
+  const chargingBus = dependencies.find((edge) => edge.relation === 'charges')!.source;
+  for (const source of assets.filter((item) =>
+    ['utility', 'generator', 'battery'].includes(item.kind),
+  )) {
+    const reachable = new Set([source.id]);
+    for (const item of topo(assets, dependencies, 'feeds')) {
+      if (reachable.has(item))
+        for (const edge of dependencies)
+          if (edge.relation === 'feeds' && edge.source === item) reachable.add(edge.target);
+    }
+    if (!reachable.has(load))
+      throw new InputError(`Source ${source.id} has no feed path to the load`);
+    if (source.kind === 'utility' && !reachable.has(chargingBus))
+      throw new InputError('The charging bus has no utility feed path');
+  }
+  for (const item of events) {
+    if (item.at_s >= duration_s)
+      throw new InputError('Events must occur before the simulation end');
+    const valid = item.action.startsWith('domain_') ? domains : byId;
+    if (!valid.has(item.target))
+      throw new InputError('Event refers to an unknown asset or failure domain');
+    if (item.action === 'set_demand' && item.target !== load)
+      throw new InputError('set_demand must target the load asset');
+  }
+  return {
+    schema_version: 2,
+    id: text(data.id, 'id'),
+    name: text(data.name, 'name'),
+    currency,
+    duration_s,
+    step_s,
+    it_demand_kw: decimalText(it_demand),
+    it_capacity_kw: decimalText(it_capacity),
+    distribution_efficiency: decimalText(distribution),
+    tariff_per_kwh: tariff === null ? null : decimalText(tariff),
+    generator_cost_per_kwh: generatorCost === null ? null : decimalText(generatorCost),
+    generator_start_delay_s,
+    battery_capacity_kwh: decimalText(batteryCapacity),
+    battery_initial_kwh: decimalText(batteryInitial),
+    battery_charge_kw: decimalText(batteryCharge),
+    battery_charge_efficiency: decimalText(chargeEfficiency),
+    battery_discharge_efficiency: decimalText(dischargeEfficiency),
+    source_ids,
+    assets,
+    dependencies,
+    events,
+  };
+}
+
+export function topologicalOrder(scenario: SiteScenario, relation: string): string[] {
+  return topo(scenario.assets, scenario.dependencies, relation);
+}
+
+export function parseQuantity(value: string, name = 'value'): Rational {
+  return Rational.fromDecimal(value, name);
+}

--- a/apps/web/src/js-engine/decimal.ts
+++ b/apps/web/src/js-engine/decimal.ts
@@ -1,0 +1,330 @@
+/** Exact non-negative input decimals and signed rational arithmetic.
+ *
+ * The Python continuity engine keeps all simulation quantities as Fraction
+ * values and only converts at the JSON boundary with a 100 digit, half-even
+ * Decimal context.  This module mirrors that boundary without using binary
+ * floating point for any model quantity.
+ */
+
+export class InputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InputError';
+  }
+}
+
+function abs(value: bigint): bigint {
+  return value < 0n ? -value : value;
+}
+
+function gcd(left: bigint, right: bigint): bigint {
+  left = abs(left);
+  right = abs(right);
+  while (right !== 0n) {
+    const next = left % right;
+    left = right;
+    right = next;
+  }
+  return left || 1n;
+}
+
+function pow10(exponent: bigint): bigint {
+  if (exponent < 0n) throw new Error('Negative power of ten');
+  // Scenario inputs are bounded to nine decimal places.  Intermediate
+  // quantities remain small enough for this conversion; keep a guard so a
+  // malformed direct value cannot allocate an unbounded integer.
+  if (exponent > 100000n) throw new InputError('numeric representation is too long');
+  return 10n ** exponent;
+}
+
+// Python's Decimal parser accepts every Unicode Nd digit and ignores ASCII
+// underscores in the numeric text.  Normalize those forms before applying the
+// deliberately small decimal grammar below.  The ranges are the Unicode
+// decimal-digit blocks; mathematical digits have five adjacent blocks.
+const UNICODE_DIGIT_RANGES: readonly [number, number][] = [
+  [0x30, 0x39],
+  [0x660, 0x669],
+  [0x6f0, 0x6f9],
+  [0x7c0, 0x7c9],
+  [0x966, 0x96f],
+  [0x9e6, 0x9ef],
+  [0xa66, 0xa6f],
+  [0xae6, 0xaef],
+  [0xb66, 0xb6f],
+  [0xbe6, 0xbef],
+  [0xc66, 0xc6f],
+  [0xce6, 0xcef],
+  [0xd66, 0xd6f],
+  [0xde6, 0xdef],
+  [0xe50, 0xe59],
+  [0xed0, 0xed9],
+  [0xf20, 0xf29],
+  [0x1040, 0x1049],
+  [0x1090, 0x1099],
+  [0x17e0, 0x17e9],
+  [0x1810, 0x1819],
+  [0x1946, 0x194f],
+  [0x19d0, 0x19d9],
+  [0x1a80, 0x1a89],
+  [0x1a90, 0x1a99],
+  [0x1b50, 0x1b59],
+  [0x1bb0, 0x1bb9],
+  [0x1c40, 0x1c49],
+  [0x1c50, 0x1c59],
+  [0xa620, 0xa629],
+  [0xa8d0, 0xa8d9],
+  [0xa900, 0xa909],
+  [0xa9d0, 0xa9d9],
+  [0xa9f0, 0xa9f9],
+  [0xaa50, 0xaa59],
+  [0xabf0, 0xabf9],
+  [0xff10, 0xff19],
+  [0x104a0, 0x104a9],
+  [0x10d30, 0x10d39],
+  [0x11066, 0x1106f],
+  [0x110f0, 0x110f9],
+  [0x11136, 0x1113f],
+  [0x111d0, 0x111d9],
+  [0x112f0, 0x112f9],
+  [0x11450, 0x11459],
+  [0x114d0, 0x114d9],
+  [0x11650, 0x11659],
+  [0x116c0, 0x116c9],
+  [0x11730, 0x11739],
+  [0x118e0, 0x118e9],
+  [0x11950, 0x11959],
+  [0x11c50, 0x11c59],
+  [0x11d50, 0x11d59],
+  [0x11da0, 0x11da9],
+  [0x11f50, 0x11f59],
+  [0x16a60, 0x16a69],
+  [0x16ac0, 0x16ac9],
+  [0x16b50, 0x16b59],
+  [0x1d7ce, 0x1d7d7],
+  [0x1d7d8, 0x1d7e1],
+  [0x1d7e2, 0x1d7eb],
+  [0x1d7ec, 0x1d7f5],
+  [0x1d7f6, 0x1d7ff],
+  [0x1e140, 0x1e149],
+  [0x1e2f0, 0x1e2f9],
+  [0x1e4f0, 0x1e4f9],
+  [0x1e950, 0x1e959],
+  [0x1fbf0, 0x1fbf9],
+];
+
+function normalizeDecimalText(input: string): string {
+  return Array.from(input.trim())
+    .filter((character) => character !== '_')
+    .map((character) => {
+      const codePoint = character.codePointAt(0)!;
+      for (const [start, end] of UNICODE_DIGIT_RANGES)
+        if (codePoint >= start && codePoint <= end) return String(codePoint - start);
+      return character;
+    })
+    .join('');
+}
+
+/** A reduced signed rational. Denominator is always positive. */
+export class Rational {
+  readonly numerator: bigint;
+  readonly denominator: bigint;
+
+  constructor(numerator: bigint | number, denominator: bigint | number = 1n) {
+    let n = BigInt(numerator);
+    let d = BigInt(denominator);
+    if (d === 0n) throw new Error('Division by zero');
+    if (d < 0n) {
+      n = -n;
+      d = -d;
+    }
+    if (n === 0n) {
+      this.numerator = 0n;
+      this.denominator = 1n;
+      return;
+    }
+    const divisor = gcd(n, d);
+    this.numerator = n / divisor;
+    this.denominator = d / divisor;
+  }
+
+  static zero(): Rational {
+    return new Rational(0n);
+  }
+
+  static one(): Rational {
+    return new Rational(1n);
+  }
+
+  static fromInteger(value: number | bigint): Rational {
+    return new Rational(BigInt(value));
+  }
+
+  static fromDecimal(
+    value: unknown,
+    name = 'value',
+    options: { positive?: boolean } = {},
+  ): Rational {
+    if (typeof value !== 'string' && typeof value !== 'number')
+      throw new InputError(`${name}: expected a finite decimal number`);
+    if (typeof value === 'number' && !Number.isFinite(value))
+      throw new InputError(`${name}: expected a finite decimal number`);
+    const rawInput = String(value);
+    if (Array.from(rawInput).length > 128)
+      throw new InputError(`${name}: numeric representation is too long`);
+    const input = normalizeDecimalText(rawInput);
+    const match = input.trim().match(/^([+-]?)(?:(\d+)(?:\.(\d*))?|\.(\d+))(?:[eE]([+-]?\d+))?$/);
+    if (!match) throw new InputError(`${name}: expected a finite decimal number`);
+    const sign = match[1] === '-' ? -1n : 1n;
+    const integerPart = match[2] ?? '';
+    const fractionPart = match[3] ?? match[4] ?? '';
+    const exponentText = match[5] ?? '0';
+    let exponent: bigint;
+    try {
+      exponent = BigInt(exponentText);
+    } catch {
+      throw new InputError(`${name}: expected a finite decimal number`);
+    }
+    // Decimal.as_tuple().exponent is the effective exponent after accounting
+    // for written fractional digits; trailing zeroes therefore remain subject
+    // to the Python contract's nine-place bound.
+    const effectiveExponent = exponent - BigInt(fractionPart.length);
+    if (effectiveExponent < -9n)
+      throw new InputError(`${name}: maximum 1e12 with at most nine decimal places`);
+    const digitsText = `${integerPart}${fractionPart}`.replace(/^0+(?=\d)/, '') || '0';
+    let numerator: bigint;
+    try {
+      numerator =
+        BigInt(digitsText) *
+        pow10(exponent < BigInt(fractionPart.length) ? 0n : exponent - BigInt(fractionPart.length));
+    } catch (error) {
+      if (error instanceof InputError) throw error;
+      throw new InputError(`${name}: expected a finite decimal number`);
+    }
+    let denominator = 1n;
+    const decimalPlaces = BigInt(fractionPart.length) - exponent;
+    if (decimalPlaces > 0n) {
+      if (decimalPlaces > 100000n)
+        throw new InputError(`${name}: numeric representation is too long`);
+      // The branch above used no scale for negative effective exponents.
+      numerator = BigInt(digitsText);
+      denominator = pow10(decimalPlaces);
+    }
+    const result = new Rational(sign * numerator, denominator);
+    if (result.numerator < 0n || (options.positive === true && result.numerator === 0n))
+      throw new InputError(`${name}: must be ${options.positive ? 'positive' : 'nonnegative'}`);
+    if (result.compare(new Rational(1000000000000n)) > 0)
+      throw new InputError(`${name}: maximum 1e12 with at most nine decimal places`);
+    return result;
+  }
+
+  add(other: Rational): Rational {
+    return new Rational(
+      this.numerator * other.denominator + other.numerator * this.denominator,
+      this.denominator * other.denominator,
+    );
+  }
+
+  sub(other: Rational): Rational {
+    return new Rational(
+      this.numerator * other.denominator - other.numerator * this.denominator,
+      this.denominator * other.denominator,
+    );
+  }
+
+  mul(other: Rational): Rational {
+    return new Rational(this.numerator * other.numerator, this.denominator * other.denominator);
+  }
+
+  div(other: Rational): Rational {
+    return new Rational(this.numerator * other.denominator, this.denominator * other.numerator);
+  }
+
+  neg(): Rational {
+    return new Rational(-this.numerator, this.denominator);
+  }
+
+  compare(other: Rational): number {
+    const left = this.numerator * other.denominator;
+    const right = other.numerator * this.denominator;
+    return left < right ? -1 : left > right ? 1 : 0;
+  }
+
+  isZero(): boolean {
+    return this.numerator === 0n;
+  }
+
+  isPositive(): boolean {
+    return this.numerator > 0n;
+  }
+
+  toDecimal(): string {
+    return decimalText(this);
+  }
+
+  toMoney(): string | null {
+    return moneyText(this);
+  }
+}
+
+function roundHalfEven(numerator: bigint, denominator: bigint): bigint {
+  if (denominator <= 0n || numerator < 0n) throw new Error('Expected nonnegative division');
+  const quotient = numerator / denominator;
+  const remainder = numerator % denominator;
+  const twice = remainder * 2n;
+  if (twice > denominator || (twice === denominator && quotient % 2n === 1n)) return quotient + 1n;
+  return quotient;
+}
+
+function decimalExponent(numerator: bigint, denominator: bigint): number {
+  let exponent = numerator.toString().length - denominator.toString().length;
+  if (exponent >= 0) {
+    if (numerator < denominator * pow10(BigInt(exponent))) exponent -= 1;
+  } else if (numerator * pow10(BigInt(-exponent)) < denominator) {
+    exponent -= 1;
+  }
+  return exponent;
+}
+
+/** Python Decimal( n ) / Decimal( d ) under prec=100, ROUND_HALF_EVEN, f format. */
+export function decimalText(value: Rational): string {
+  if (value.isZero()) return '0';
+  const negative = value.numerator < 0n;
+  const numerator = abs(value.numerator);
+  const denominator = value.denominator;
+  const exponent = decimalExponent(numerator, denominator);
+  const scale = 99 - exponent;
+  const scaledNumerator = scale >= 0 ? numerator * pow10(BigInt(scale)) : numerator;
+  const scaledDenominator = scale >= 0 ? denominator : denominator * pow10(BigInt(-scale));
+  const coefficient = roundHalfEven(scaledNumerator, scaledDenominator);
+  let digits = coefficient.toString();
+  let output: string;
+  if (scale >= 0) {
+    const point = digits.length - scale;
+    if (point <= 0) output = `0.${'0'.repeat(-point)}${digits}`;
+    else if (point >= digits.length) output = `${digits}${'0'.repeat(point - digits.length)}`;
+    else output = `${digits.slice(0, point)}.${digits.slice(point)}`;
+  } else {
+    output = `${digits}${'0'.repeat(-scale)}`;
+  }
+  if (output.includes('.')) output = output.replace(/0+$/, '').replace(/\.$/, '');
+  if (output === '' || output === '0') return '0';
+  return negative ? `-${output}` : output;
+}
+
+/** Python Decimal(...).quantize(Decimal("0.01"), ROUND_HALF_EVEN). */
+export function moneyText(value: Rational | null): string | null {
+  if (value === null) return null;
+  const negative = value.numerator < 0n;
+  const rounded = roundHalfEven(abs(value.numerator) * 100n, value.denominator);
+  const whole = rounded / 100n;
+  const cents = (rounded % 100n).toString().padStart(2, '0');
+  return `${negative ? '-' : ''}${whole.toString()}.${cents}`;
+}
+
+export function rational(value: number | bigint): Rational {
+  return Rational.fromInteger(value);
+}
+
+export function parseDecimal(value: unknown, name = 'value', positive = false): Rational {
+  return Rational.fromDecimal(value, name, { positive });
+}

--- a/apps/web/src/js-engine/index.ts
+++ b/apps/web/src/js-engine/index.ts
@@ -1,0 +1,39 @@
+export { canonicalJson, sha256Hex } from './canonical';
+export {
+  InputError,
+  Rational,
+  decimalText,
+  decimalText as toDecimal,
+  moneyText,
+  moneyText as toMoney,
+  parseDecimal,
+  rational,
+} from './decimal';
+export { parseQuantity, validateScenario, topologicalOrder } from './contract';
+export {
+  FlowNetwork,
+  simulateContinuity,
+  simulateContinuitySync,
+  simulateValidated,
+} from './continuity';
+export { sweepContinuity } from './sweep';
+export { renderHtml, renderMarkdown } from './report';
+export { normalizeQuote } from './quotes';
+export { simulatePlanning, validatePlanningScenario } from './planning';
+export { ENGINE_VERSION } from './version';
+export type { Catalog, CatalogOffer } from './quotes';
+export type { PlanningRun, PlanningScenario, PlanningSegment } from './planning';
+export type {
+  Asset,
+  Dependency,
+  DecimalInput,
+  Interval,
+  JsonValue,
+  Run,
+  ScenarioEvent,
+  SiteScenario,
+  Summary,
+  Sweep,
+  SweepRun,
+  DemoData,
+} from './types';

--- a/apps/web/src/js-engine/planning.ts
+++ b/apps/web/src/js-engine/planning.ts
@@ -1,0 +1,229 @@
+import { canonicalJson, sha256Hex } from './canonical';
+import { decimalText, InputError, moneyText, Rational } from './decimal';
+import type { JsonValue } from './types';
+import { ENGINE_VERSION } from './version';
+
+const LIMITATIONS = [
+  'Demand estimate; supply continuity and delivered service are not simulated.',
+  'PUE is an input assumption; cooling and losses must not be added again.',
+  'Energy-only cost excludes demand charges, CAPEX, taxes and all other charges.',
+  'Capacity screen does not establish electrical feasibility, resilience or certification.',
+];
+
+export interface PlanningSegment {
+  label: string;
+  hours: string;
+  it_load_kw: string;
+  assumed_pue: string;
+}
+
+export interface PlanningScenario {
+  schema_version: 1;
+  id: string;
+  name: string;
+  currency: 'USD' | 'EUR' | 'INR';
+  it_capacity_kw: string;
+  tariff_per_kwh: string | null;
+  price_status: 'illustrative' | 'unknown';
+  assumption_date: string;
+  source_ids: string[];
+  segments: PlanningSegment[];
+}
+
+export interface PlanningRun {
+  schema_version: 1;
+  engine_version: string;
+  run_id: string;
+  input_sha256: string;
+  scenario_id: string;
+  scenario_name: string;
+  mode: 'SYNTHETIC_PLANNING';
+  fidelity: 'coarse_assumed_pue';
+  evidence_level: 'arithmetic_verified_only';
+  source_ids: string[];
+  assumptions: PlanningScenario;
+  currency: PlanningScenario['currency'];
+  boundary: string;
+  duration_hours: string;
+  it_energy_kwh: string;
+  facility_energy_kwh: string;
+  non_it_energy_kwh: string;
+  period_pue: string | null;
+  pue_undefined_reason: string | null;
+  peak_it_demand_kw: string;
+  it_capacity_margin_kw: string;
+  capacity_screen: 'exceeds_envelope' | 'within_envelope';
+  energy_only_cost: string | null;
+  cost_unknown_reason: string | null;
+  intervals: Record<string, JsonValue>[];
+  limitations: string[];
+}
+
+function object(value: unknown, name: string): Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value))
+    throw new InputError(`${name}: expected an object`);
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(data: Record<string, unknown>, keys: string[], name: string): void {
+  const expected = new Set(keys);
+  const missing = keys.filter((key) => !Object.prototype.hasOwnProperty.call(data, key));
+  const extra = Object.keys(data).filter((key) => !expected.has(key));
+  if (missing.length || extra.length)
+    throw new InputError(
+      `${name}: missing fields [${missing.join(', ')}]; unknown fields [${extra.join(', ')}]`,
+    );
+}
+
+function stringValue(value: unknown, name: string): string {
+  if (typeof value !== 'string' || !value.trim() || Array.from(value).length > 200)
+    throw new InputError(`${name}: expected nonempty text of at most 200 characters`);
+  return value;
+}
+
+function list(value: unknown, name: string): string[] {
+  if (!Array.isArray(value) || value.length === 0 || value.length > 100)
+    throw new InputError(`${name}: expected 1 to 100 reference identifiers`);
+  return value.map((item) => stringValue(item, name));
+}
+
+function dateValue(value: unknown): string {
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value))
+    throw new InputError('assumption_date: use a valid YYYY-MM-DD date');
+  const date = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(date.getTime()) || date.toISOString().slice(0, 10) !== value)
+    throw new InputError('assumption_date: use a valid YYYY-MM-DD date');
+  return value;
+}
+
+function segment(value: unknown): PlanningSegment {
+  const data = object(value, 'segment');
+  exactKeys(data, ['label', 'hours', 'it_load_kw', 'assumed_pue'], 'segment');
+  const hours = Rational.fromDecimal(data.hours, 'hours', { positive: true });
+  const load = Rational.fromDecimal(data.it_load_kw, 'it_load_kw');
+  const pue = Rational.fromDecimal(data.assumed_pue, 'assumed_pue', { positive: true });
+  if (pue.compare(Rational.one()) < 0)
+    throw new InputError('assumed_pue: must be at least 1 in the coarse energy boundary');
+  return {
+    label: stringValue(data.label, 'label'),
+    hours: decimalText(hours),
+    it_load_kw: decimalText(load),
+    assumed_pue: decimalText(pue),
+  };
+}
+
+export function validatePlanningScenario(input: unknown): PlanningScenario {
+  const data = object(input, 'scenario');
+  exactKeys(
+    data,
+    [
+      'schema_version',
+      'id',
+      'name',
+      'currency',
+      'it_capacity_kw',
+      'tariff_per_kwh',
+      'price_status',
+      'assumption_date',
+      'source_ids',
+      'segments',
+    ],
+    'scenario',
+  );
+  if (data.schema_version !== 1 || typeof data.schema_version !== 'number')
+    throw new InputError('schema_version: only integer 1 is supported');
+  const currency = data.currency;
+  if (currency !== 'USD' && currency !== 'EUR' && currency !== 'INR')
+    throw new InputError('currency: use USD, EUR, or INR; automatic FX is not implemented');
+  const priceStatus = data.price_status;
+  if (priceStatus !== 'illustrative' && priceStatus !== 'unknown')
+    throw new InputError('price_status: the preliminary contract supports illustrative or unknown');
+  const tariff =
+    data.tariff_per_kwh === null
+      ? null
+      : Rational.fromDecimal(data.tariff_per_kwh, 'tariff_per_kwh');
+  if ((tariff === null) !== (priceStatus === 'unknown'))
+    throw new InputError(
+      'tariff_per_kwh: null must have unknown status; a value must be illustrative',
+    );
+  if (!Array.isArray(data.segments) || data.segments.length > 10000)
+    throw new InputError('segments: expected a list with at most 10000 intervals');
+  const result: PlanningScenario = {
+    schema_version: 1,
+    id: stringValue(data.id, 'id'),
+    name: stringValue(data.name, 'name'),
+    currency,
+    it_capacity_kw: decimalText(
+      Rational.fromDecimal(data.it_capacity_kw, 'it_capacity_kw', { positive: true }),
+    ),
+    tariff_per_kwh: tariff === null ? null : decimalText(tariff),
+    price_status: priceStatus,
+    assumption_date: dateValue(data.assumption_date),
+    source_ids: list(data.source_ids, 'source_id'),
+    segments: data.segments.map(segment),
+  };
+  return result;
+}
+
+export function simulatePlanning(input: unknown): PlanningRun {
+  const scenario = validatePlanningScenario(input);
+  const canonical = canonicalJson(scenario as never);
+  const inputHash = sha256Hex(canonical);
+  const runId = sha256Hex(`${ENGINE_VERSION}:${inputHash}`).slice(0, 20);
+  let totalHours = Rational.zero();
+  let itEnergy = Rational.zero();
+  let facilityEnergy = Rational.zero();
+  let peakIt = Rational.zero();
+  const intervals: Record<string, JsonValue>[] = [];
+  const capacity = Rational.fromDecimal(scenario.it_capacity_kw);
+  for (const current of scenario.segments) {
+    const hours = Rational.fromDecimal(current.hours);
+    const load = Rational.fromDecimal(current.it_load_kw);
+    const pue = Rational.fromDecimal(current.assumed_pue);
+    const itKwh = load.mul(hours);
+    const facilityKw = load.mul(pue);
+    const facilityKwh = facilityKw.mul(hours);
+    intervals.push({
+      ...current,
+      facility_demand_kw: decimalText(facilityKw),
+      it_energy_kwh: decimalText(itKwh),
+      facility_energy_kwh: decimalText(facilityKwh),
+      exceeds_it_capacity: load.compare(capacity) > 0,
+    });
+    totalHours = totalHours.add(hours);
+    itEnergy = itEnergy.add(itKwh);
+    facilityEnergy = facilityEnergy.add(facilityKwh);
+    if (load.compare(peakIt) > 0) peakIt = load;
+  }
+  const tariff =
+    scenario.tariff_per_kwh === null ? null : Rational.fromDecimal(scenario.tariff_per_kwh);
+  const cost = tariff === null ? null : moneyText(facilityEnergy.mul(tariff));
+  return {
+    schema_version: 1,
+    engine_version: ENGINE_VERSION,
+    run_id: runId,
+    input_sha256: inputHash,
+    scenario_id: scenario.id,
+    scenario_name: scenario.name,
+    mode: 'SYNTHETIC_PLANNING',
+    fidelity: 'coarse_assumed_pue',
+    evidence_level: 'arithmetic_verified_only',
+    source_ids: scenario.source_ids,
+    assumptions: scenario,
+    currency: scenario.currency,
+    boundary: 'IT demand plus aggregate non-IT overhead; all facility energy assumed grid-imported',
+    duration_hours: decimalText(totalHours),
+    it_energy_kwh: decimalText(itEnergy),
+    facility_energy_kwh: decimalText(facilityEnergy),
+    non_it_energy_kwh: decimalText(facilityEnergy.sub(itEnergy)),
+    period_pue: itEnergy.isZero() ? null : decimalText(facilityEnergy.div(itEnergy)),
+    pue_undefined_reason: itEnergy.isZero() ? 'No IT energy in this period' : null,
+    peak_it_demand_kw: decimalText(peakIt),
+    it_capacity_margin_kw: decimalText(capacity.sub(peakIt)),
+    capacity_screen: peakIt.compare(capacity) > 0 ? 'exceeds_envelope' : 'within_envelope',
+    energy_only_cost: cost,
+    cost_unknown_reason: cost === null ? 'Tariff is unknown' : null,
+    intervals,
+    limitations: LIMITATIONS,
+  };
+}

--- a/apps/web/src/js-engine/quotes.ts
+++ b/apps/web/src/js-engine/quotes.ts
@@ -1,0 +1,91 @@
+import { decimalText, InputError, moneyText, Rational } from './decimal';
+
+function object(value: unknown, name: string): Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value))
+    throw new InputError(`${name}: expected an object`);
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(data: Record<string, unknown>, keys: string[], name: string): void {
+  const expected = new Set(keys);
+  const missing = keys.filter((key) => !Object.prototype.hasOwnProperty.call(data, key));
+  const extra = Object.keys(data).filter((key) => !expected.has(key));
+  if (missing.length || extra.length)
+    throw new InputError(
+      `${name}: missing fields [${missing.join(', ')}]; unknown fields [${extra.join(', ')}]`,
+    );
+}
+
+function stringValue(value: unknown, name: string): string {
+  if (typeof value !== 'string' || !value.trim() || Array.from(value).length > 200)
+    throw new InputError(`${name}: expected nonempty text of at most 200 characters`);
+  return value;
+}
+
+function integer(value: unknown, name: string, low: number, high: number): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < low || value > high)
+    throw new InputError(`${name}: expected an integer from ${low} to ${high}`);
+  return value;
+}
+
+export interface CatalogOffer {
+  id: string;
+  gpu_count: number;
+  billing_unit: string;
+  currency: string;
+  source_ids: string[];
+  [key: string]: unknown;
+}
+
+export interface Catalog {
+  cloud_offers?: CatalogOffer[];
+  [key: string]: unknown;
+}
+
+export function normalizeQuote(input: unknown, catalog: Catalog): Record<string, unknown> {
+  const data = object(input, 'quote');
+  exactKeys(data, ['offer_id', 'node_count', 'billed_hours', 'assumed_rate'], 'quote');
+  const offerId = stringValue(data.offer_id, 'offer_id');
+  const offer = (catalog.cloud_offers ?? []).find((item) => item.id === offerId);
+  if (!offer) throw new InputError('offer_id: unknown catalogue offer');
+  const count = integer(data.node_count, 'node_count', 1, 100000);
+  const hours = Rational.fromDecimal(data.billed_hours, 'billed_hours');
+  const rate =
+    data.assumed_rate === null ? null : Rational.fromDecimal(data.assumed_rate, 'assumed_rate');
+  const gpuCount = offer.gpu_count;
+  const nodeHours = Rational.fromInteger(count).mul(hours);
+  const units =
+    offer.billing_unit === 'gpu_hour' ? nodeHours.mul(Rational.fromInteger(gpuCount)) : nodeHours;
+  const total = rate === null ? null : units.mul(rate);
+  const nodeRate =
+    rate === null
+      ? null
+      : rate.mul(
+          offer.billing_unit === 'gpu_hour' ? Rational.fromInteger(gpuCount) : Rational.one(),
+        );
+  const gpuRate = nodeRate === null ? null : nodeRate.div(Rational.fromInteger(gpuCount));
+  return {
+    offer,
+    inputs: {
+      offer_id: offerId,
+      node_count: count,
+      billed_hours: decimalText(hours),
+      assumed_rate: rate === null ? null : decimalText(rate),
+    },
+    billing_unit: offer.billing_unit,
+    billed_units: decimalText(units),
+    billed_node_hours: decimalText(nodeHours),
+    normalized_node_hour_rate: nodeRate === null ? null : decimalText(nodeRate),
+    provisioned_gpu_hour_rate: gpuRate === null ? null : decimalText(gpuRate),
+    cost: moneyText(total),
+    currency: offer.currency,
+    price_status: rate === null ? 'unknown' : 'user_assumption',
+    source_ids: offer.source_ids,
+    calibrated: false,
+    limitations: [
+      'User-entered rate is an assumption, not a fetched vendor quote.',
+      'Already-billed hours exclude invoice granularity, minimums, taxes and ancillary charges.',
+      'No workload throughput, utilization, region availability or performance equivalence is inferred.',
+    ],
+  };
+}

--- a/apps/web/src/js-engine/report.ts
+++ b/apps/web/src/js-engine/report.ts
@@ -1,0 +1,385 @@
+import { compareUnicode } from './canonical';
+import { InputError } from './decimal';
+
+function pyString(value: unknown): string {
+  if (value === null || value === undefined) return 'None';
+  if (value === true) return 'True';
+  if (value === false) return 'False';
+  if (Array.isArray(value)) return `[${value.map(pyString).join(', ')}]`;
+  if (typeof value === 'object') return '[object Object]';
+  return String(value);
+}
+
+function md(value: unknown): string {
+  let text = value === null || value === undefined ? '' : pyString(value);
+  text = text.replaceAll('\r\n', ' ').replaceAll('\n', ' ').replaceAll('\r', ' ');
+  text = text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+  for (const character of [
+    '\\',
+    '|',
+    '`',
+    '*',
+    '_',
+    '[',
+    ']',
+    '(',
+    ')',
+    '#',
+    '!',
+    '>',
+    '+',
+    '-',
+    '~',
+  ])
+    text = text.replaceAll(character, `\\${character}`);
+  return text;
+}
+
+function html(value: unknown): string {
+  return pyString(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#x27;');
+}
+
+function object(value: unknown, name: string): Record<string, any> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value))
+    throw new InputError(`${name}: expected an object`);
+  return value as Record<string, any>;
+}
+
+function requireResult(result: unknown): Record<string, any> {
+  const value = object(result, 'Report result');
+  if (!object(value.scenario ?? value.base_scenario, 'Report result'))
+    throw new InputError('Report result must include a scenario');
+  if (
+    !Object.prototype.hasOwnProperty.call(value, 'summary') &&
+    !(
+      Object.prototype.hasOwnProperty.call(value, 'runs') &&
+      Object.prototype.hasOwnProperty.call(value, 'parameter')
+    )
+  )
+    throw new InputError('Report result must be a continuity run or sensitivity sweep');
+  return value;
+}
+
+function scenario(result: Record<string, any>): Record<string, any> {
+  return result.scenario || result.base_scenario || {};
+}
+
+function scenarioRows(input: Record<string, any>): [string, string, string][] {
+  const units: Record<string, string> = {
+    duration_s: 's',
+    step_s: 's',
+    it_demand_kw: 'kW',
+    it_capacity_kw: 'kW',
+    distribution_efficiency: 'ratio',
+    generator_start_delay_s: 's',
+    battery_capacity_kwh: 'kWh',
+    battery_initial_kwh: 'kWh',
+    battery_charge_kw: 'kW',
+    battery_charge_efficiency: 'ratio',
+    battery_discharge_efficiency: 'ratio',
+    tariff_per_kwh: 'currency/kWh',
+    generator_cost_per_kwh: 'currency/kWh',
+  };
+  const keys = [
+    'id',
+    'name',
+    'currency',
+    'duration_s',
+    'step_s',
+    'it_demand_kw',
+    'it_capacity_kw',
+    'distribution_efficiency',
+    'generator_start_delay_s',
+    'battery_capacity_kwh',
+    'battery_initial_kwh',
+    'battery_charge_kw',
+    'battery_charge_efficiency',
+    'battery_discharge_efficiency',
+    'tariff_per_kwh',
+    'generator_cost_per_kwh',
+  ];
+  return keys.map((key) => [
+    key,
+    pyString(Object.prototype.hasOwnProperty.call(input, key) ? input[key] : 'unknown'),
+    units[key] || '',
+  ]);
+}
+
+function warnings(run: Record<string, any>): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const interval of run.intervals || [])
+    for (const warning of interval.warnings || [])
+      counts.set(String(warning), (counts.get(String(warning)) || 0) + 1);
+  return counts;
+}
+
+function singleSummary(result: Record<string, any>): Record<string, any> {
+  const summary = { ...(result.summary || {}) };
+  summary.requested_kwh ??= summary.requested_it_kwh ?? 'unknown';
+  summary.served_kwh ??= summary.served_it_kwh ?? 'unknown';
+  summary.unserved_kwh ??= summary.unserved_it_kwh ?? 'unknown';
+  summary.unserved_seconds ??= summary.unserved_duration_s ?? 'unknown';
+  summary.first_battery_depletion_s ??=
+    (result.events || []).find((event: any) => event.action === 'battery_depleted')?.at_s ?? null;
+  summary.cost_unknowns ??= ['generator_energy_charge', 'total_incremental_energy_charge'].filter(
+    (key) => summary[key] === null,
+  );
+  return summary;
+}
+
+function summaryRows(summary: Record<string, any>): [string, unknown, string][] {
+  const depletion = summary.first_battery_depletion_s;
+  return [
+    ['Requested IT energy', summary.requested_kwh ?? 'unknown', 'kWh'],
+    ['Served IT energy', summary.served_kwh ?? 'unknown', 'kWh'],
+    ['Unserved IT energy', summary.unserved_kwh ?? 'unknown', 'kWh'],
+    ['Unserved duration', summary.unserved_seconds ?? 'unknown', 's'],
+    [
+      'First battery depletion',
+      depletion === null || depletion === undefined ? 'none' : depletion,
+      's',
+    ],
+    ['Battery final energy', summary.battery_final_kwh ?? 'unknown', 'kWh'],
+    ['Peak unserved demand', summary.peak_unserved_kw ?? 'unknown', 'kW'],
+    ['Service status', summary.service_status ?? 'unknown', ''],
+    ['Cost status', summary.cost_status ?? 'unknown', ''],
+    ['Cost unknowns', (summary.cost_unknowns || []).join(', ') || 'none', ''],
+    ['Energy balance residual', summary.energy_balance_residual_kwh ?? 'unknown', 'kWh'],
+  ];
+}
+
+function markdownTable(headers: string[], rows: unknown[][]): string[] {
+  const lines = [`| ${headers.join(' | ')} |`, `| ${headers.map(() => '---').join(' | ')} |`];
+  lines.push(...rows.map((row) => `| ${row.map(md).join(' | ')} |`));
+  return lines;
+}
+
+function eventRows(result: Record<string, any>): unknown[][] {
+  return (result.events || []).map((event: any) => [
+    event.at_s ?? 'unknown',
+    event.action ?? 'unknown',
+    event.target ?? 'unknown',
+    event.origin ?? 'scenario',
+    event.ready_at_s ?? '',
+  ]);
+}
+
+function sweepRows(result: Record<string, any>): { rows: unknown[][]; warningLines: string[] } {
+  const rows: unknown[][] = [];
+  const counts = new Map<string, number>();
+  for (const entry of result.runs || []) {
+    const summary = entry.summary || {};
+    rows.push([
+      entry.value_label ?? entry.value ?? 'unknown',
+      summary.requested_kwh ?? summary.requested_it_kwh ?? 'unknown',
+      summary.served_kwh ?? summary.served_it_kwh ?? 'unknown',
+      summary.unserved_kwh ?? summary.unserved_it_kwh ?? 'unknown',
+      summary.unserved_seconds ?? summary.unserved_duration_s ?? 'unknown',
+      summary.first_battery_depletion_s === null || summary.first_battery_depletion_s === undefined
+        ? 'none'
+        : summary.first_battery_depletion_s,
+      summary.service_status ?? 'unknown',
+      (summary.cost_unknowns || []).join(', ') || 'none',
+      entry.run_id ?? 'unknown',
+      entry.input_sha256 ?? 'unknown',
+    ]);
+    if (entry.result)
+      for (const [name, count] of warnings(entry.result))
+        counts.set(name, (counts.get(name) || 0) + count);
+    else
+      for (const [name, count] of Object.entries(summary.warning_counts || {}))
+        counts.set(String(name), (counts.get(String(name)) || 0) + Number(count));
+  }
+  return {
+    rows,
+    warningLines: Array.from(counts)
+      .sort(([left], [right]) => compareUnicode(left, right))
+      .map(([name, count]) => `${name}: ${count} interval(s)`),
+  };
+}
+
+export function renderMarkdown(input: unknown): string {
+  const result = requireResult(input);
+  const sweep =
+    Object.prototype.hasOwnProperty.call(result, 'runs') &&
+    Object.prototype.hasOwnProperty.call(result, 'parameter');
+  const currentScenario = scenario(result);
+  const lines = [
+    '# Datacenter Twin Lab continuity report',
+    '',
+    `Model: ${md(result.model ?? 'unknown')}`,
+    `Engine version: ${md(result.engine_version ?? 'unknown')}`,
+  ];
+  let warningLines: string[];
+  if (sweep) {
+    lines.push(
+      `Base input SHA-256: ${md(result.base_input_sha256 ?? 'unknown')}`,
+      `Parameter: ${md(result.parameter ?? 'unknown')} (${md(result.parameter_unit ?? '')})`,
+      '',
+      '## Sensitivity outcomes',
+      '',
+    );
+    const rows = sweepRows(result);
+    warningLines = rows.warningLines;
+    lines.push(
+      ...markdownTable(
+        [
+          'Value',
+          'Requested (kWh)',
+          'Served (kWh)',
+          'Unserved (kWh)',
+          'Unserved (s)',
+          'Battery depletion (s)',
+          'Service',
+          'Cost unknowns',
+          'Run ID',
+          'Input SHA-256',
+        ],
+        rows.rows,
+      ),
+    );
+  } else {
+    lines.push(
+      `Run ID: ${md(result.run_id ?? 'unknown')}`,
+      `Input SHA-256: ${md(result.input_sha256 ?? 'unknown')}`,
+      '',
+      '## Outcome',
+      '',
+    );
+    lines.push(...markdownTable(['Measure', 'Value', 'Unit'], summaryRows(singleSummary(result))));
+    lines.push('', '## Event timeline', '');
+    const rows = eventRows(result);
+    lines.push(
+      ...(rows.length
+        ? markdownTable(['At (s)', 'Action', 'Target', 'Origin', 'Ready at (s)'], rows)
+        : ['No events were emitted.']),
+    );
+    warningLines = Array.from(warnings(result))
+      .sort(([left], [right]) => compareUnicode(left, right))
+      .map(([name, count]) => `${name}: ${count} interval(s)`);
+  }
+  lines.push(
+    '',
+    '## Scenario assumptions',
+    '',
+    ...markdownTable(['Field', 'Value', 'Unit'], scenarioRows(currentScenario)),
+    '',
+    '## Warning summary',
+    '',
+    ...(warningLines.length
+      ? markdownTable(
+          ['Warning', 'Count'],
+          warningLines.map((item) => item.split(/: (?=\d+ interval)/)),
+        )
+      : ['No interval warnings were emitted.']),
+  );
+  if (sweep)
+    lines.push('', `Full per-run results included: ${md(result.full_results_included ?? false)}`);
+  lines.push(
+    '',
+    '## Assumptions',
+    '',
+    ...(result.assumptions || []).map((item: unknown) => `- ${md(item)}`),
+    '',
+    '## Limitations',
+    '',
+    ...(result.limitations || []).map((item: unknown) => `- ${md(item)}`),
+  );
+  return `${lines.join('\n')}\n`;
+}
+
+function htmlTable(headers: string[], rows: unknown[][]): string {
+  const head = headers.map((value) => `<th>${html(value)}</th>`).join('');
+  const body = rows
+    .map((row) => `<tr>${row.map((value) => `<td>${html(value)}</td>`).join('')}</tr>`)
+    .join('');
+  return `<table><thead><tr>${head}</tr></thead><tbody>${body}</tbody></table>`;
+}
+
+export function renderHtml(input: unknown): string {
+  const result = requireResult(input);
+  const sweep =
+    Object.prototype.hasOwnProperty.call(result, 'runs') &&
+    Object.prototype.hasOwnProperty.call(result, 'parameter');
+  const currentScenario = scenario(result);
+  const title = 'Datacenter Twin Lab continuity report';
+  const parts = [
+    '<!doctype html>',
+    '<html lang="en">',
+    '<head><meta charset="utf-8"><title>Datacenter Twin Lab continuity report</title><style>body{font-family:system-ui,sans-serif;max-width:1100px;margin:2rem auto;padding:0 1rem}table{border-collapse:collapse;margin:1rem 0;width:100%}th,td{border:1px solid #ccc;padding:.35rem;text-align:left}th{background:#f2f2f2}code{word-break:break-all}</style></head><body>',
+    `<h1>${html(title)}</h1>`,
+    `<p>Model: <code>${html(result.model ?? 'unknown')}</code><br>Engine version: <code>${html(result.engine_version ?? 'unknown')}</code></p>`,
+  ];
+  let warningLines: string[];
+  if (sweep) {
+    parts.push(
+      `<p>Base input SHA-256: <code>${html(result.base_input_sha256 ?? 'unknown')}</code><br>Parameter: <code>${html(result.parameter ?? 'unknown')}</code> (${html(result.parameter_unit ?? '')})</p>`,
+    );
+    const rows = sweepRows(result);
+    warningLines = rows.warningLines;
+    parts.push(
+      '<h2>Sensitivity outcomes</h2>',
+      htmlTable(
+        [
+          'Value',
+          'Requested (kWh)',
+          'Served (kWh)',
+          'Unserved (kWh)',
+          'Unserved (s)',
+          'Battery depletion (s)',
+          'Service',
+          'Cost unknowns',
+          'Run ID',
+          'Input SHA-256',
+        ],
+        rows.rows,
+      ),
+    );
+  } else {
+    parts.push(
+      `<p>Run ID: <code>${html(result.run_id ?? 'unknown')}</code><br>Input SHA-256: <code>${html(result.input_sha256 ?? 'unknown')}</code></p>`,
+      '<h2>Outcome</h2>',
+      htmlTable(['Measure', 'Value', 'Unit'], summaryRows(singleSummary(result))),
+      '<h2>Event timeline</h2>',
+    );
+    const rows = eventRows(result);
+    parts.push(
+      rows.length
+        ? htmlTable(['At (s)', 'Action', 'Target', 'Origin', 'Ready at (s)'], rows)
+        : '<p>No events were emitted.</p>',
+    );
+    warningLines = Array.from(warnings(result))
+      .sort(([left], [right]) => compareUnicode(left, right))
+      .map(([name, count]) => `${name}: ${count} interval(s)`);
+  }
+  parts.push(
+    '<h2>Scenario assumptions</h2>',
+    htmlTable(['Field', 'Value', 'Unit'], scenarioRows(currentScenario)),
+    '<h2>Warning summary</h2>',
+    warningLines.length
+      ? htmlTable(
+          ['Warning', 'Count'],
+          warningLines.map((item) => item.split(/: (?=\d+ interval)/)),
+        )
+      : '<p>No interval warnings were emitted.</p>',
+  );
+  if (sweep)
+    parts.push(
+      `<p>Full per-run results included: ${html(result.full_results_included ?? false)}</p>`,
+    );
+  for (const [heading, key] of [
+    ['Assumptions', 'assumptions'],
+    ['Limitations', 'limitations'],
+  ] as const)
+    parts.push(
+      `<h2>${heading}</h2>`,
+      `<ul>${(result[key] || []).map((item: unknown) => `<li>${html(item)}</li>`).join('')}</ul>`,
+    );
+  parts.push('</body>', '</html>');
+  return `${parts.join('\n')}\n`;
+}

--- a/apps/web/src/js-engine/sweep.ts
+++ b/apps/web/src/js-engine/sweep.ts
@@ -1,0 +1,119 @@
+import { canonicalJson, compareUnicode } from './canonical';
+import { decimalText, InputError, Rational } from './decimal';
+import { simulateValidated } from './continuity';
+import { validateScenario } from './contract';
+import type { SiteScenario, Sweep, Summary } from './types';
+import { ENGINE_VERSION } from './version';
+
+const UNITS: Record<string, string> = {
+  battery_initial_kwh: 'kWh',
+  it_demand_kw: 'kW',
+  generator_start_delay_s: 's',
+  distribution_efficiency: 'ratio',
+};
+const PARAMETERS = new Set(Object.keys(UNITS));
+const MAX_FULL_RESULT_BYTES = 16 * 1024 * 1024;
+
+function summary(run: ReturnType<typeof simulateValidated>): Summary {
+  const warningCounts: Record<string, number> = {};
+  for (const interval of run.intervals)
+    for (const warning of interval.warnings)
+      warningCounts[warning] = (warningCounts[warning] ?? 0) + 1;
+  const firstBattery = run.events.find((event) => event.action === 'battery_depleted');
+  const result: Summary = { ...run.summary };
+  result.requested_kwh = run.summary.requested_it_kwh;
+  result.served_kwh = run.summary.served_it_kwh;
+  result.unserved_kwh = run.summary.unserved_it_kwh;
+  result.unserved_seconds = run.summary.unserved_duration_s;
+  result.first_battery_depletion_s = firstBattery?.at_s ?? null;
+  result.cost_unknowns = ['generator_energy_charge', 'total_incremental_energy_charge'].filter(
+    (key) => run.summary[key] === null,
+  );
+  result.warning_counts = warningCounts;
+  return result;
+}
+
+function parseSweepValue(
+  value: unknown,
+  parameter: string,
+  index: number,
+): { label: string; parsed: Rational } {
+  if (typeof value !== 'string' && typeof value !== 'number')
+    throw new InputError(`values[${index}]: expected a finite decimal value`);
+  const parsed = Rational.fromDecimal(value, `values[${index}]`);
+  if (parameter === 'generator_start_delay_s' && parsed.denominator !== 1n)
+    throw new InputError(
+      `values[${index}]: generator_start_delay_s must be an integer number of seconds`,
+    );
+  return { label: decimalText(parsed), parsed };
+}
+
+export function sweepContinuity(input: unknown, parameter: string, values: unknown[]): Sweep {
+  const scenario = validateScenario(input);
+  if (!PARAMETERS.has(parameter))
+    throw new InputError(
+      `parameter: expected one of ${Array.from(PARAMETERS).sort(compareUnicode).join(', ')}`,
+    );
+  if (!Array.isArray(values) || values.length === 0)
+    throw new InputError('values: expected a nonempty list');
+  if (values.length > 20) throw new InputError('values: at most 20 values are supported');
+  const parsed = values.map((value, index) => parseSweepValue(value, parameter, index));
+  if (new Set(parsed.map((item) => item.label)).size !== parsed.length)
+    throw new InputError('values: duplicate value');
+  const baseRun = simulateValidated(scenario);
+  const runs: Sweep['runs'] = [];
+  const fullResults: ReturnType<typeof simulateValidated>[] = [];
+  let fullSize = 0;
+  let includeFull = true;
+  for (const item of parsed) {
+    const candidate = {
+      ...scenario,
+      [parameter]:
+        parameter === 'generator_start_delay_s' ? Number(item.parsed.numerator) : item.label,
+    } as SiteScenario;
+    const run = simulateValidated(validateScenario(candidate));
+    const result = run;
+    if (includeFull) {
+      fullSize += new TextEncoder().encode(canonicalJson(result as never)).byteLength;
+      if (fullSize <= MAX_FULL_RESULT_BYTES) fullResults.push(result);
+      else {
+        includeFull = false;
+        fullResults.length = 0;
+      }
+    }
+    runs.push({
+      value: item.label,
+      value_label: `${item.label} ${UNITS[parameter]}`,
+      value_unit: UNITS[parameter],
+      run_id: run.run_id,
+      input_sha256: run.input_sha256,
+      summary: summary(run),
+    });
+  }
+  if (includeFull)
+    for (let index = 0; index < runs.length; index++) runs[index].result = fullResults[index];
+  return {
+    schema_version: 2,
+    model: 'single_load_electrical_continuity_sensitivity_v1',
+    engine_version: ENGINE_VERSION,
+    base_run_id: baseRun.run_id,
+    base_input_sha256: baseRun.input_sha256,
+    base_scenario: scenario,
+    parameter,
+    parameter_unit: UNITS[parameter],
+    values: parsed.map((item) => item.label),
+    runs,
+    full_results_included: includeFull,
+    full_results_limit_bytes: MAX_FULL_RESULT_BYTES,
+    assumptions: [
+      'Each value is evaluated from the same starting schema-v2 scenario.',
+      'Values change one scenario field; battery capacity and all other topology inputs remain fixed.',
+      'Energy accounting is exact within the synthetic single-IT-load continuity model.',
+    ],
+    limitations: [
+      'This is a deterministic sensitivity sweep, not calibration or a forecast.',
+      'Cooling, workload queues, switching transients, protection studies and physical controls are outside the model.',
+      'Costs remain illustrative or unknown according to the scenario tariff and generator cost inputs.',
+    ],
+  };
+}

--- a/apps/web/src/js-engine/types.ts
+++ b/apps/web/src/js-engine/types.ts
@@ -1,0 +1,123 @@
+export interface Asset {
+  id: string;
+  name: string;
+  kind: string;
+  capacity_kw: string;
+  failure_domains: string[];
+  source_ids: string[];
+}
+
+export interface Dependency {
+  source: string;
+  target: string;
+  relation: string;
+}
+
+export interface ScenarioEvent {
+  at_s: number;
+  action: string;
+  target: string;
+  value_kw: string | null;
+}
+
+export interface SiteScenario {
+  schema_version: 2;
+  id: string;
+  name: string;
+  currency: 'USD' | 'EUR' | 'INR';
+  duration_s: number;
+  step_s: number;
+  it_demand_kw: string;
+  it_capacity_kw: string;
+  distribution_efficiency: string;
+  tariff_per_kwh: string | null;
+  generator_cost_per_kwh: string | null;
+  generator_start_delay_s: number;
+  battery_capacity_kwh: string;
+  battery_initial_kwh: string;
+  battery_charge_kw: string;
+  battery_charge_efficiency: string;
+  battery_discharge_efficiency: string;
+  source_ids: string[];
+  assets: Asset[];
+  dependencies: Dependency[];
+  events: ScenarioEvent[];
+}
+
+export interface DemoData {
+  engine_version: string;
+  presets: { id: string; name: string }[];
+  scenarios: Record<string, SiteScenario>;
+}
+
+export interface Interval {
+  start_s: string;
+  end_s: string;
+  duration_s: string;
+  requested_it_kw: string;
+  served_it_kw: string;
+  unserved_it_kw: string;
+  electrical_source_kw: string;
+  grid_kw: string;
+  generator_kw: string;
+  battery_discharge_kw: string;
+  battery_charge_kw: string;
+  battery_start_kwh: string;
+  battery_end_kwh: string;
+  it_capacity_margin_kw: string;
+  grid_energy_charge_to_date: string | null;
+  energy: Record<string, string>;
+  energy_balance_residual_kwh: string;
+  asset_states: Record<string, string>;
+  warnings: string[];
+  feed_flows_kw: { source: string; target: string; kw: string }[];
+}
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+export type Summary = { [key: string]: JsonValue };
+
+export interface Run {
+  schema_version: 2;
+  model: 'single_load_electrical_continuity_v1';
+  engine_version: string;
+  run_id: string;
+  input_sha256: string;
+  mode: 'SIMULATED';
+  quality: 'synthetic_uncalibrated';
+  scenario: SiteScenario;
+  intervals: Interval[];
+  events: Record<string, JsonValue>[];
+  summary: Summary;
+  boundary: string;
+  limitations: string[];
+}
+
+export type DecimalInput = string | number;
+
+export interface SweepRun {
+  value: string;
+  value_label: string;
+  value_unit: string;
+  run_id: string;
+  input_sha256: string;
+  summary: Summary;
+  result?: Run;
+}
+
+export interface Sweep {
+  schema_version: 2;
+  model: 'single_load_electrical_continuity_sensitivity_v1';
+  engine_version: string;
+  base_run_id: string;
+  base_input_sha256: string;
+  base_scenario: SiteScenario;
+  parameter: string;
+  parameter_unit: string;
+  values: string[];
+  runs: SweepRun[];
+  full_results_included: boolean;
+  full_results_limit_bytes: number;
+  assumptions: string[];
+  limitations: string[];
+}

--- a/apps/web/src/js-engine/version.ts
+++ b/apps/web/src/js-engine/version.ts
@@ -1,0 +1,1 @@
+export const ENGINE_VERSION = '0.3.0a0';

--- a/apps/web/src/python-client.ts
+++ b/apps/web/src/python-client.ts
@@ -1,0 +1,7 @@
+import { createWorkerRequest } from './worker-request';
+
+// Imported only after the visitor enables Python verification.
+export const pythonRequest = createWorkerRequest(
+  () => new Worker(new URL('./browser-worker.ts', import.meta.url), { type: 'module' }),
+  'Python verification',
+);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1210,3 +1210,60 @@ tr:last-child td {
     scroll-behavior: auto !important;
   }
 }
+
+/* Course controls keep one question, one changed input and one result together. */
+.course {
+  display: grid;
+  gap: 20px;
+}
+.course-navigation label,
+.course-experiment label {
+  display: grid;
+  gap: 8px;
+  max-width: 560px;
+}
+.course-navigation select,
+.course-experiment input {
+  padding: 10px;
+  width: 100%;
+}
+.course-navigation progress {
+  width: min(360px, 80%);
+  margin-right: 12px;
+  accent-color: var(--accent);
+}
+.course-question {
+  font-size: 1.2rem;
+}
+.course-experiment form {
+  margin: 20px 0;
+}
+.course-result {
+  display: grid;
+  gap: 10px;
+  padding: 20px 0;
+}
+.course-result strong {
+  font-size: clamp(1.5rem, 4vw, 2.5rem);
+  overflow-wrap: anywhere;
+}
+.worked-answer {
+  padding: 16px;
+  border-left: 3px solid #30c7ad;
+  line-height: 1.7;
+}
+.lesson-paging {
+  margin-top: 24px;
+}
+.python-verification label {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  font-weight: 600;
+}
+.python-verification input {
+  width: auto;
+}
+.python-verification p {
+  overflow-wrap: anywhere;
+}

--- a/apps/web/src/worker-request.ts
+++ b/apps/web/src/worker-request.ts
@@ -1,0 +1,64 @@
+type Pending = {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  cleanup: () => void;
+};
+
+/** A bounded, cancellable request channel. Workers are created on first use. */
+export function createWorkerRequest(createWorker: () => Worker, label: string) {
+  let worker: Worker | undefined;
+  let sequence = 0;
+  const pending = new Map<number, Pending>();
+  function stop(error: Error) {
+    worker?.terminate();
+    worker = undefined;
+    for (const item of pending.values()) {
+      item.cleanup();
+      item.reject(error);
+    }
+    pending.clear();
+  }
+  async function request<T>(path: string, signal?: AbortSignal, body?: unknown): Promise<T> {
+    if (signal?.aborted) throw new DOMException('Cancelled', 'AbortError');
+    const json = JSON.stringify(body ?? null);
+    if (new TextEncoder().encode(json).byteLength > 4 * 1024 * 1024)
+      throw new Error('Request exceeds the 4 MiB input limit');
+    if (!worker) {
+      worker = createWorker();
+      worker.onmessage = ({ data }) => {
+        const item = pending.get(data.id);
+        if (!item) return;
+        pending.delete(data.id);
+        item.cleanup();
+        if (data.error) item.reject(new Error(data.error));
+        else item.resolve(data.result);
+      };
+      worker.onerror = () => stop(new Error(`${label} could not start. Try again or reload.`));
+    }
+    return new Promise<T>((resolve, reject) => {
+      const id = ++sequence;
+      const abort = () => {
+        const item = pending.get(id);
+        pending.delete(id);
+        item?.cleanup();
+        reject(new DOMException('Cancelled', 'AbortError'));
+        if (!pending.size) stop(new DOMException('Cancelled', 'AbortError'));
+      };
+      const timer = setTimeout(
+        () => stop(new Error(`${label} timed out. Try a smaller scenario or retry.`)),
+        90_000,
+      );
+      pending.set(id, {
+        resolve: (value) => resolve(value as T),
+        reject,
+        cleanup: () => {
+          clearTimeout(timer);
+          signal?.removeEventListener('abort', abort);
+        },
+      });
+      signal?.addEventListener('abort', abort, { once: true });
+      worker!.postMessage({ id, path, body: json });
+    });
+  }
+  return request;
+}

--- a/apps/web/tests-demo/course.spec.ts
+++ b/apps/web/tests-demo/course.spec.ts
@@ -1,0 +1,153 @@
+import { test, expect, type Page } from '@playwright/test';
+import { execFileSync } from 'node:child_process';
+import { readFile, writeFile } from 'node:fs/promises';
+import { lessons } from '../src/course-lessons';
+
+async function exported(page: Page, planning = false) {
+  const pending = page.waitForEvent('download');
+  await page
+    .getByRole('button', { name: planning ? 'Export PUE calculation' : 'Export lesson run' })
+    .click();
+  return JSON.parse(await readFile((await (await pending).path())!, 'utf8'));
+}
+
+function nativeRun(run: { schema_version: number; scenario: unknown; assumptions: unknown }) {
+  const planning = run.schema_version === 1;
+  return JSON.parse(
+    execFileSync(
+      process.env.TWIN_PYTHON || 'python',
+      [
+        '-c',
+        planning
+          ? 'import json,sys;from datacenter_twin.contracts import Scenario;from datacenter_twin.engine import simulate;print(json.dumps(simulate(Scenario.from_dict(json.load(sys.stdin)))))'
+          : 'import json,sys;from datacenter_twin.topology import SiteScenario;from datacenter_twin.continuity import simulate_continuity;print(json.dumps(simulate_continuity(SiteScenario.from_dict(json.load(sys.stdin))).to_dict()))',
+      ],
+      {
+        cwd: '../..',
+        input: JSON.stringify(planning ? run.assumptions : run.scenario),
+        encoding: 'utf8',
+        maxBuffer: 16 * 1024 * 1024,
+      },
+    ),
+  );
+}
+
+// These expectations come from power × time, efficiency products and the
+// stated event times. Native equality additionally covers every exported field.
+const expected: Record<string, [number, number]> = {
+  'power-energy': [500, 250],
+  'distribution-loss': [500 / 0.95, 500 / 0.9],
+  'ride-through': [607.8, 453.9],
+  'generator-delay': [330, 360],
+  'generator-failure': [292.2, 0],
+  'n-plus-one': [335, 0],
+  'shared-controls': [1000, 335],
+  'single-point': [1000 / 6, 0],
+  precharge: [478.2675, 453.9],
+  'ai-outage': [607.8, 478.2675],
+  'recovery-deadline': [0.1865, 0],
+  pue: [547500000, 503700000],
+};
+
+test('all twelve lessons run both exercises and export complete native-equal results', async ({
+  page,
+}) => {
+  test.setTimeout(180000);
+  await page.goto('./?lesson=power-energy');
+  for (const lesson of lessons) {
+    await page.getByLabel('Choose a lesson').selectOption(lesson.id);
+    await expect(page.getByTestId('lesson-result')).toBeVisible();
+    for (let exercise = 0; exercise < 2; exercise++) {
+      if (exercise) {
+        await page.getByRole('button', { name: 'Try the challenge value' }).click();
+        await expect(
+          page.getByText('Input changed. Run the lesson to update the result.'),
+        ).toBeVisible();
+        await page.getByRole('button', { name: 'Run lesson', exact: true }).click();
+        await expect(page.getByTestId('lesson-result')).toContainText(
+          `Result for ${lesson.challenge}`,
+        );
+      }
+      const run = await exported(page, lesson.id === 'pue');
+      expect(run).toEqual(nativeRun(run));
+      const actual =
+        lesson.id === 'pue'
+          ? run.facility_energy_kwh
+          : lesson.resultKey === 'generator_ready'
+            ? run.intervals.find(
+                (row: { asset_states: Record<string, string> }) =>
+                  row.asset_states.generator === 'running',
+              )?.start_s
+            : lesson.resultKey === 'depletion'
+              ? run.events.find((event: { action: string }) => event.action === 'battery_depleted')
+                  ?.at_s
+              : run.summary[lesson.resultKey];
+      expect(Number(actual)).toBeCloseTo(expected[lesson.id][exercise], 7);
+      if (lesson.id !== 'pue') expect(run.summary.energy_balance_residual_kwh).toBe('0');
+    }
+    await page.getByRole('button', { name: 'Show worked answer' }).click();
+    await expect(page.locator('.worked-answer')).toBeVisible();
+  }
+  await page.getByLabel('Verify against Python').check();
+  await expect(page.getByTestId('python-verification-status')).toContainText(
+    'Exact match with Python',
+  );
+});
+
+test('cold first result requests no Python runtime or cover and records observed payload', async ({
+  page,
+  context,
+}, testInfo) => {
+  const responses: Promise<{ path: string; bytes: number }>[] = [];
+  context.on('response', (response) => {
+    if (response.url().startsWith('http://127.0.0.1:4174/'))
+      responses.push(
+        response.body().then((body) => ({
+          path: new URL(response.url()).pathname,
+          bytes: body.byteLength,
+        })),
+      );
+  });
+  const started = performance.now();
+  await page.goto('./');
+  await expect(page.getByTestId('served-power')).toHaveText('50,000 kW');
+  const firstResultMs = performance.now() - started;
+  const assets = await Promise.all(responses);
+  expect(
+    assets.some((asset) => /pyodide|engine\.zip|engine-manifest|cover/i.test(asset.path)),
+  ).toBe(false);
+  const decodedBytes = assets.reduce((sum, asset) => sum + asset.bytes, 0);
+  expect(decodedBytes).toBeLessThan(600000);
+  await writeFile(
+    testInfo.outputPath('first-result-measurement.json'),
+    JSON.stringify(
+      {
+        measured_at: new Date().toISOString(),
+        scenario: 'ai_cluster_generator_failure',
+        environment:
+          'Fresh Playwright Chromium context; loopback Vite preview; no network or CPU throttle',
+        first_result_ms: Math.round(firstResultMs),
+        decoded_response_bytes: decodedBytes,
+        assets,
+        limitations:
+          'One local observation; decoded payload, not a global visitor latency benchmark or compressed transfer size.',
+      },
+      null,
+      2,
+    ),
+  );
+});
+
+test('course works at phone width and navigation returns to the simulator', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('./?lesson=ai-outage');
+  await expect(page.getByTestId('lesson-result')).toContainText('607.8');
+  await page.getByRole('button', { name: 'Try the challenge value' }).click();
+  await page.getByRole('button', { name: 'Run lesson', exact: true }).click();
+  await expect(page.getByTestId('lesson-result')).toContainText('478.2675');
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+  await page.screenshot({ path: 'test-results/course-phone.png', fullPage: true });
+  await page.getByRole('button', { name: 'Simulator', exact: true }).click();
+  await expect(page.getByTestId('served-power')).toBeVisible();
+  expect(new URL(page.url()).searchParams.has('lesson')).toBe(false);
+});

--- a/apps/web/tests-demo/demo.spec.ts
+++ b/apps/web/tests-demo/demo.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, type Page } from '@playwright/test';
 import { execFileSync } from 'node:child_process';
-import { readFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 
 async function exported(page: Page) {
   const pending = page.waitForEvent('download');
@@ -38,13 +38,15 @@ test('all presets match native Python with external network blocked and no API',
   );
   page.on('request', (request) => requests.push(request.url()));
   await page.goto('./');
-  await expect(page.getByTestId('served-power')).toContainText('1,000');
+  await expect(page.getByTestId('served-power')).toContainText('50,000');
   for (const preset of [
     'generator_failure',
     'normal',
     'utility_loss',
     'path_maintenance',
     'shared_domain',
+    'ai_cluster_utility_loss',
+    'ai_cluster_generator_failure',
   ]) {
     await page.getByLabel('Scenario', { exact: true }).selectOption(preset);
     await expect(page.getByRole('button', { name: 'Run scenario' })).toBeEnabled();
@@ -52,13 +54,19 @@ test('all presets match native Python with external network blocked and no API',
     expect(run).toEqual(nativeRun(run.scenario));
     expect(run.summary.energy_balance_residual_kwh).toBe('0');
   }
-  expect(requests.filter((url) => url.includes('/api/'))).toEqual([]);
+  expect(requests.filter((url) => /\/api\/|pyodide|engine\.zip|engine-manifest/.test(url))).toEqual(
+    [],
+  );
+  await page.getByLabel('Verify against Python').check();
+  await expect(page.getByTestId('python-verification-status')).toContainText(
+    'Exact match with Python',
+  );
 });
 
 test('failure journey changes energy, replays recovery, and exports reports and a sweep', async ({
   page,
 }) => {
-  await page.goto('./');
+  await page.goto('./?preset=generator_failure');
   await expect(page.getByRole('button', { name: 'Battery depleted 607.8 s' })).toBeVisible();
   await page.getByLabel('Initial battery (kWh)').fill('50');
   await page.getByRole('button', { name: 'Run scenario' }).click();
@@ -81,14 +89,23 @@ test('failure journey changes energy, replays recovery, and exports reports and 
   await page.screenshot({ path: 'test-results/browser-demo-desktop.png', fullPage: true });
 });
 
-test('archive corruption fails visibly and phone layout stays within the viewport', async ({
+test('optional verifier rejects corrupt source while the JavaScript result stays usable', async ({
   page,
 }) => {
   await page.route('**/engine.zip', (route) => route.fulfill({ body: 'corrupted archive' }));
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto('./');
+  await expect(page.getByTestId('served-power')).toContainText('50,000');
+  await page.getByLabel('Verify against Python').check();
   await expect(page.getByRole('alert')).toContainText('integrity check failed');
-  await expect(page.getByRole('button', { name: 'Retry', exact: true })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Retry Python verification' })).toBeVisible();
+  const run = await exported(page);
+  expect(run).toEqual(nativeRun(run.scenario));
+  await page.unroute('**/engine.zip');
+  await page.getByRole('button', { name: 'Retry Python verification' }).click();
+  await expect(page.getByTestId('python-verification-status')).toContainText(
+    'Exact match with Python',
+  );
   expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
 });
 
@@ -97,11 +114,45 @@ test('phone visitor can run and inspect a scenario without horizontal overflow',
 }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto('./');
-  await expect(page.getByTestId('served-power')).toContainText('1,000');
+  await expect(page.getByTestId('served-power')).toContainText('50,000');
   await page.getByRole('button', { name: 'Battery depleted 607.8 s' }).click();
   await expect(page.getByTestId('served-power')).toHaveText('0 kW');
   expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
   await page.screenshot({ path: 'test-results/browser-demo-phone.png', fullPage: true });
+});
+
+test('a Python mismatch is visible and cannot replace the completed JavaScript result', async ({
+  page,
+}) => {
+  await page.route('**/assets/browser-worker-*.js', (route) =>
+    route.fulfill({
+      contentType: 'application/javascript',
+      body: "self.addEventListener('message', ({data}) => self.postMessage({id:data.id,result:{run_id:'deliberate-test-mismatch'}}));",
+    }),
+  );
+  await page.goto('./');
+  await expect(page.getByTestId('served-power')).toHaveText('50,000 kW');
+  const original = await exported(page);
+  await page.getByLabel('Verify against Python').check();
+  await expect(page.getByRole('alert')).toContainText('JavaScript and Python results differ');
+  expect(await exported(page)).toEqual(original);
+  await expect(page.getByText('Exact match with Python', { exact: false })).toHaveCount(0);
+});
+
+test('turning off verification cancels the pending check and a new run stays JavaScript-only', async ({
+  page,
+}) => {
+  await page.goto('./');
+  await expect(page.getByTestId('served-power')).toHaveText('50,000 kW');
+  await page.getByLabel('Verify against Python').check();
+  await expect(page.getByTestId('python-verification-status')).toContainText('Loading Python');
+  await page.getByLabel('Verify against Python').uncheck();
+  await page.getByLabel('Initial battery (kWh)').fill('2500');
+  await page.getByRole('button', { name: 'Run scenario' }).click();
+  await expect(page.getByRole('button', { name: 'Battery depleted 478.3 s' })).toBeVisible();
+  await expect(page.getByTestId('python-verification-status')).toHaveCount(0);
+  const run = await exported(page);
+  expect(run).toEqual(nativeRun(run.scenario));
 });
 
 test('a visitor without JavaScript can read the example and find the Python route', async ({

--- a/apps/web/tests-engine/engine.test.ts
+++ b/apps/web/tests-engine/engine.test.ts
@@ -1,0 +1,275 @@
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+import {
+  decimalText,
+  moneyText,
+  Rational,
+  simulateContinuitySync,
+  validateScenario,
+} from '../src/js-engine/index';
+import type { DemoData } from '../src/js-engine/index';
+
+const root = resolve(process.cwd(), '../..');
+const demoData = JSON.parse(
+  readFileSync(resolve(root, '.local/browser-demo-assets/demo-data.json'), 'utf8'),
+) as DemoData;
+
+function preset(name: string): Record<string, unknown> {
+  return structuredClone(demoData.scenarios[name]) as Record<string, unknown>;
+}
+
+test('exact arithmetic keeps Python-compatible decimal and money boundaries', () => {
+  assert.equal(
+    decimalText(new Rational(1n, 3n)),
+    '0.3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333',
+  );
+  assert.equal(decimalText(new Rational(1n, 2n)), '0.5');
+  assert.equal(Rational.fromDecimal('１２.５').toDecimal(), '12.5');
+  assert.equal(Rational.fromDecimal('١٢.٥').toDecimal(), '12.5');
+  assert.equal(Rational.fromDecimal('1_2.5').toDecimal(), '12.5');
+  assert.equal(moneyText(new Rational(1n, 200n)), '0.00');
+  assert.equal(moneyText(new Rational(3n, 200n)), '0.02');
+  assert.equal(moneyText(new Rational(5n, 200n)), '0.02');
+});
+
+test('seven public presets retain independent continuity expectations', () => {
+  const normal = simulateContinuitySync(preset('normal'));
+  assert.equal(normal.summary.served_it_kwh, '500');
+  assert.equal(normal.summary.unserved_it_kwh, '0');
+  const failure = simulateContinuitySync(preset('generator_failure'));
+  assert.equal(failure.events.find((event) => event.action === 'battery_depleted')?.at_s, '607.8');
+  assert.equal(failure.summary.unserved_duration_s, '292.2');
+  const path = simulateContinuitySync(preset('path_maintenance'));
+  const pathRow = path.intervals.find((row) => row.start_s === '300')!;
+  assert.equal(pathRow.served_it_kw, '665');
+  assert.equal(pathRow.unserved_it_kw, '335');
+  const shared = simulateContinuitySync(preset('shared_domain'));
+  assert.equal(shared.intervals.find((row) => row.start_s === '300')!.served_it_kw, '0');
+  for (const name of demoData.presets.map((item) => item.id)) {
+    const run = simulateContinuitySync(preset(name));
+    for (const row of run.intervals) assert.equal(row.energy_balance_residual_kwh, '0');
+  }
+});
+
+test('charging, depletion, demand events, partial paths, and unknown costs are explicit', () => {
+  const empty = simulateContinuitySync({
+    ...preset('generator_failure'),
+    battery_initial_kwh: '0',
+  });
+  assert.equal(empty.events.find((event) => event.action === 'battery_depleted')?.at_s, '324.3675');
+  const charged50 = simulateContinuitySync({
+    ...preset('generator_failure'),
+    battery_initial_kwh: '50',
+  });
+  assert.equal(
+    charged50.events.find((event) => event.action === 'battery_depleted')?.at_s,
+    '478.2675',
+  );
+  const deadline57 = simulateContinuitySync({
+    ...preset('generator_failure'),
+    duration_s: 600,
+    battery_initial_kwh: '57',
+    events: [
+      { at_s: 300, action: 'asset_down', target: 'utility', value_kw: null },
+      { at_s: 300, action: 'asset_down', target: 'generator', value_kw: null },
+      { at_s: 500, action: 'asset_up', target: 'utility', value_kw: null },
+      { at_s: 500, action: 'asset_up', target: 'generator', value_kw: null },
+    ],
+  });
+  assert.equal(
+    deadline57.events.find((event) => event.action === 'battery_depleted')?.at_s,
+    '499.8135',
+  );
+  const changedDemand = simulateContinuitySync({
+    ...preset('normal'),
+    events: [{ at_s: 10, action: 'set_demand', target: 'it-load', value_kw: '500' }],
+  });
+  assert.equal(changedDemand.intervals.find((row) => row.start_s === '10')!.requested_it_kw, '500');
+  const unknown = simulateContinuitySync({
+    ...preset('utility_loss'),
+    generator_cost_per_kwh: null,
+  });
+  assert.equal(unknown.summary.generator_energy_charge, null);
+  assert.equal(unknown.summary.total_incremental_energy_charge, null);
+  const coincident = simulateContinuitySync({
+    ...preset('normal'),
+    battery_initial_kwh: '99',
+    battery_charge_efficiency: '1',
+    step_s: 60,
+  });
+  assert.equal(coincident.intervals[0].end_s, '36');
+  assert.equal(coincident.summary.battery_final_kwh, '100');
+});
+
+test('validation rejects bounded-contract violations and preserves arbitrary schema-2 topology', () => {
+  assert.equal(validateScenario(preset('normal')).schema_version, 2);
+  for (const patch of [
+    { distribution_efficiency: '1.01' },
+    { battery_initial_kwh: '101' },
+    { duration_s: true },
+    { duration_s: 86400, step_s: 1 },
+    { schema_version: 1 },
+    { tariff_per_kwh: 'NaN' },
+    { it_demand_kw: '-1' },
+    { currency: 'GBP' },
+  ])
+    assert.throws(() => validateScenario({ ...preset('normal'), ...patch }));
+  const custom = structuredClone(preset('normal')) as Record<string, any>;
+  custom.assets.push({
+    id: 'extra-bus',
+    name: 'Extra bus',
+    kind: 'bus',
+    capacity_kw: '100',
+    failure_domains: ['extra'],
+    source_ids: ['test'],
+  });
+  custom.dependencies.push({ source: 'main-bus', target: 'extra-bus', relation: 'requires' });
+  assert.equal(validateScenario(custom).assets.length, 9);
+});
+
+function nativePython(payload: Record<string, unknown>): string | null {
+  const source = [
+    'import sys,json',
+    'sys.path.insert(0, sys.argv[1])',
+    'from datacenter_twin.topology import SiteScenario',
+    'from datacenter_twin.continuity import simulate_continuity',
+    'payload=json.load(sys.stdin)',
+    'print(json.dumps({k:simulate_continuity(SiteScenario.from_dict(v)).to_dict() for k,v in payload.items()},separators=(",",":")))',
+  ].join('\n');
+  const candidates =
+    process.platform === 'win32'
+      ? [resolve(root, '.venv/Scripts/python.exe'), 'python.exe', 'python3.exe', 'py.exe']
+      : [resolve(root, '.venv/bin/python'), 'python3', 'python'];
+  candidates.unshift(process.env.TWIN_PYTHON);
+  for (const executable of candidates.filter((value): value is string => Boolean(value))) {
+    const result = spawnSync(executable, ['-c', source, root], {
+      input: JSON.stringify(payload),
+      encoding: 'utf8',
+      cwd: root,
+      env: { ...process.env, PYTHONUTF8: '1' },
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    if (result.status === 0 && result.stdout) return result.stdout;
+  }
+  return null;
+}
+
+const presetCases = Object.fromEntries(demoData.presets.map(({ id }) => [id, preset(id)]));
+const pythonOutput = nativePython(presetCases);
+if (!pythonOutput)
+  throw new Error(
+    'Native Python differential harness unavailable; set TWIN_PYTHON to a Python 3.12+ interpreter.',
+  );
+test('complete run objects match native Python for all seven presets', () => {
+  const expected = JSON.parse(pythonOutput!);
+  for (const name of Object.keys(expected))
+    assert.deepEqual(simulateContinuitySync(preset(name)), expected[name]);
+});
+
+const edgeCases: Record<string, unknown> = {
+  battery_0: { ...preset('generator_failure'), battery_initial_kwh: '0' },
+  battery_50: { ...preset('generator_failure'), battery_initial_kwh: '50' },
+  battery_100: { ...preset('generator_failure'), battery_initial_kwh: '100' },
+  decimal_efficiencies: {
+    ...preset('generator_failure'),
+    it_demand_kw: '123.456',
+    distribution_efficiency: '0.9375',
+    battery_charge_efficiency: '0.875',
+    battery_discharge_efficiency: '0.8125',
+    battery_initial_kwh: '12.345678901',
+    generator_start_delay_s: 37,
+    step_s: 60,
+  },
+  delayed_generator: { ...preset('utility_loss'), generator_start_delay_s: 37, step_s: 60 },
+  demand_events: {
+    ...preset('normal'),
+    events: [
+      { at_s: 10, action: 'set_demand', target: 'it-load', value_kw: '500' },
+      { at_s: 20, action: 'set_demand', target: 'it-load', value_kw: '1200' },
+    ],
+  },
+  charge_full_coincidence: {
+    ...preset('normal'),
+    battery_initial_kwh: '99',
+    battery_charge_efficiency: '1',
+    step_s: 60,
+  },
+  unknown_cost: { ...preset('utility_loss'), generator_cost_per_kwh: null },
+  deadline_57: {
+    ...preset('generator_failure'),
+    duration_s: 600,
+    battery_initial_kwh: '57',
+    events: [
+      { at_s: 300, action: 'asset_down', target: 'utility', value_kw: null },
+      { at_s: 300, action: 'asset_down', target: 'generator', value_kw: null },
+      { at_s: 500, action: 'asset_up', target: 'utility', value_kw: null },
+      { at_s: 500, action: 'asset_up', target: 'generator', value_kw: null },
+    ],
+  },
+  unicode_name: { ...preset('normal'), id: 'demo-unicode', name: 'λ😀 canonical ordering' },
+  unicode_decimals: {
+    ...preset('generator_failure'),
+    it_demand_kw: '１２３.４５６',
+    distribution_efficiency: '٠.٩٣٧٥',
+    battery_charge_efficiency: '०.८७५',
+    battery_discharge_efficiency: '0.8125',
+    battery_initial_kwh: '１２.３４５６７８９０１',
+    tariff_per_kwh: '0_17.5',
+  },
+  signed_zero: {
+    ...preset('normal'),
+    it_demand_kw: '-0',
+    battery_initial_kwh: '-0.000000000',
+    tariff_per_kwh: '-0',
+    generator_cost_per_kwh: '-0',
+  },
+  long_unicode_name: { ...preset('normal'), name: '😀'.repeat(101) },
+};
+const unicodeIds = structuredClone(preset('normal')) as Record<string, any>;
+const unicodeAssetIds = [
+  '𐀀-utility',
+  '-generator',
+  'battery-🔋',
+  'bus-λ',
+  'distribution-東京',
+  'distribution-😀',
+  'bus-𐀀',
+  'load-😀',
+];
+const unicodeByOriginal = new Map(
+  unicodeIds.assets.map((asset: Record<string, string>, index: number) => [
+    asset.id,
+    unicodeAssetIds[index],
+  ]),
+);
+unicodeIds.id = 'unicode-identifiers';
+unicodeIds.name = 'non-BMP identifier ordering';
+unicodeIds.source_ids = ['source-𐀀-😀'];
+unicodeIds.assets = unicodeIds.assets.map((asset: Record<string, any>, index: number) => ({
+  ...asset,
+  id: unicodeAssetIds[index],
+  source_ids: ['source-𐀀-😀'],
+}));
+unicodeIds.dependencies = unicodeIds.dependencies.map((edge: Record<string, string>) => ({
+  ...edge,
+  source: unicodeByOriginal.get(edge.source),
+  target: unicodeByOriginal.get(edge.target),
+}));
+unicodeIds.events = unicodeIds.events.map((event: Record<string, any>) => ({
+  ...event,
+  target: unicodeByOriginal.get(event.target) ?? event.target,
+}));
+edgeCases.unicode_identifiers = unicodeIds;
+const edgePythonOutput = nativePython(edgeCases);
+if (!edgePythonOutput)
+  throw new Error(
+    'Native Python edge differential harness unavailable; set TWIN_PYTHON to a Python 3.12+ interpreter.',
+  );
+test('complete run objects match native Python for bounded edge scenarios', () => {
+  const expected = JSON.parse(edgePythonOutput!);
+  for (const name of Object.keys(expected))
+    assert.deepEqual(simulateContinuitySync(edgeCases[name]), expected[name]);
+});

--- a/apps/web/tests-engine/integration.test.ts
+++ b/apps/web/tests-engine/integration.test.ts
@@ -1,0 +1,109 @@
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+import { dispatchParsed } from '../src/javascript-worker';
+import type { DemoData } from '../src/js-engine/index';
+
+const root = resolve(process.cwd(), '../..');
+const demoData = JSON.parse(
+  readFileSync(resolve(root, '.local/browser-demo-assets/demo-data.json'), 'utf8'),
+) as DemoData;
+const catalog = JSON.parse(
+  readFileSync(resolve(root, '.local/browser-demo-assets/catalog.json'), 'utf8'),
+);
+const assets = { demoData, catalog };
+
+function pythonExecutable(): string {
+  const candidates = [
+    process.env.TWIN_PYTHON,
+    process.platform === 'win32'
+      ? resolve(root, '.venv/Scripts/python.exe')
+      : resolve(root, '.venv/bin/python'),
+    process.platform === 'win32' ? 'python.exe' : 'python3',
+  ].filter((value): value is string => Boolean(value));
+  for (const candidate of candidates) {
+    const probe = spawnSync(candidate, ['-c', 'print(1)'], { cwd: root, encoding: 'utf8' });
+    if (probe.status === 0) return candidate;
+  }
+  throw new Error(
+    'No Python interpreter found; set TWIN_PYTHON to run the required native differential harness.',
+  );
+}
+
+function native(op: string, payload: unknown): any {
+  const source = [
+    'import json,sys',
+    'sys.path.insert(0, sys.argv[1])',
+    'op=sys.argv[2]',
+    'payload=json.load(sys.stdin)',
+    'from datacenter_twin.browser import dispatch_json',
+    'if op=="dispatch": result=json.loads(dispatch_json(payload["path"], json.dumps(payload.get("body"), separators=(",",":"))))',
+    'elif op=="planning":',
+    ' from datacenter_twin.contracts import Scenario',
+    ' from datacenter_twin.engine import simulate',
+    ' result=simulate(Scenario.from_dict(payload))',
+    'elif op=="quote":',
+    ' from datacenter_twin.catalog import normalize_quote',
+    ' result=normalize_quote(payload)',
+    'elif op=="report":',
+    ' from datacenter_twin.browser import scenario_report',
+    ' result=scenario_report(payload)',
+    'elif op=="sweep":',
+    ' from datacenter_twin.browser import scenario_sweep',
+    ' result=scenario_sweep(payload)',
+    'else: raise ValueError(op)',
+    'print(json.dumps(result,ensure_ascii=True,separators=(",",":")))',
+  ].join('\n');
+  const result = spawnSync(pythonExecutable(), ['-c', source, root, op], {
+    input: JSON.stringify(payload),
+    cwd: root,
+    encoding: 'utf8',
+    env: { ...process.env, PYTHONUTF8: '1' },
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (result.status !== 0)
+    throw new Error(result.stderr || `Native Python failed (${result.status})`);
+  return JSON.parse(result.stdout);
+}
+
+test('dispatcher covers fixed demo, catalog, simulation, sweep, report, planning, and quote routes', () => {
+  assert.deepEqual(dispatchParsed('presets', null, assets), demoData.presets);
+  assert.deepEqual(
+    dispatchParsed('demo?preset=ai_cluster_generator_failure', null, assets),
+    demoData.scenarios.ai_cluster_generator_failure,
+  );
+  assert.deepEqual(dispatchParsed('catalog', null, assets), catalog);
+  const scenario = demoData.scenarios.generator_failure;
+  assert.deepEqual(
+    dispatchParsed('simulations', scenario, assets),
+    native('dispatch', { path: 'simulations', body: scenario }),
+  );
+  assert.deepEqual(
+    dispatchParsed(
+      'sweeps',
+      { scenario, parameter: 'battery_initial_kwh', values: ['100', '50', '0'] },
+      assets,
+    ),
+    native('sweep', { scenario, parameter: 'battery_initial_kwh', values: ['100', '50', '0'] }),
+  );
+  const reportBody = { scenario, format: 'markdown' };
+  assert.deepEqual(dispatchParsed('reports', reportBody, assets), native('report', reportBody));
+  const htmlReportBody = { scenario, format: 'html' };
+  assert.deepEqual(
+    dispatchParsed('reports', htmlReportBody, assets),
+    native('report', htmlReportBody),
+  );
+  const planning = JSON.parse(
+    readFileSync(resolve(root, 'data/scenarios/baseline-1mw.json'), 'utf8'),
+  );
+  assert.deepEqual(dispatchParsed('planning', planning, assets), native('planning', planning));
+  const quote = {
+    offer_id: 'azure-nd-h100',
+    node_count: 2,
+    billed_hours: '3.5',
+    assumed_rate: '98.32',
+  };
+  assert.deepEqual(dispatchParsed('quotes/normalize', quote, assets), native('quote', quote));
+});

--- a/apps/web/tests-engine/resolve-loader.mjs
+++ b/apps/web/tests-engine/resolve-loader.mjs
@@ -1,0 +1,19 @@
+// Node's native TypeScript runner intentionally requires explicit extensions.
+// This tiny test-only resolver keeps the source imports compatible with Vite's
+// normal extensionless bundling while allowing `node --experimental-strip-types`
+// to execute the differential harness directly.
+import { access } from 'node:fs/promises';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.startsWith('.') && !specifier.endsWith('.ts') && !specifier.endsWith('.mjs')) {
+    const candidate = new URL(`${specifier}.ts`, context.parentURL);
+    try {
+      await access(fileURLToPath(candidate));
+      return { url: pathToFileURL(fileURLToPath(candidate)).href, shortCircuit: true };
+    } catch {
+      // Let Node report the original resolution error for non-source imports.
+    }
+  }
+  return nextResolve(specifier, context);
+}

--- a/data/provenance/manifest.json
+++ b/data/provenance/manifest.json
@@ -12,7 +12,21 @@
       "id": "PUBLIC-FIXTURE-001",
       "source_type": "explicit_synthetic_fixture",
       "license": "Apache-2.0",
-      "notes": "1,000 kW \u00d7 8,760 h \u00d7 assumed PUE (1.25 or 1.15); tariff USD 0.10/kWh. Original mathematical examples, not a market quote or equipment validation."
+      "notes": "1,000 kW × 8,760 h × assumed PUE (1.25 or 1.15); tariff USD 0.10/kWh. Original mathematical examples, not a market quote or equipment validation."
+    },
+    {
+      "id": "SYN-AI-50MW-001",
+      "source_type": "original_synthetic_assumption",
+      "license": "Apache-2.0",
+      "assumption_date": "2026-09-12",
+      "notes": "The original 1 MW fixture is scaled by 50 in electrical demand, capacities and storage: 50 MW requested IT power, 5 MWh stored battery energy, 30-second generator delay and unchanged efficiencies/event times. An aggregate electrical load example, not measured GPU jobs, a server count, grid adequacy, equipment selection or a facility prediction."
+    },
+    {
+      "id": "EDU-POWER-001",
+      "source_type": "original_synthetic_assumption",
+      "license": "Apache-2.0",
+      "assumption_date": "2026-09-12",
+      "notes": "One-variable teaching exercises in power, energy, losses, finite storage, generator timing, path capacity, common failures, recovery and separate assumed-PUE annual energy. Worked answers apply to the stated default and challenge inputs. Path capacity is only one N+1 condition. PUE does not model cooling or supply continuity. No independent external review is claimed."
     }
   ]
 }

--- a/datacenter_twin/api.py
+++ b/datacenter_twin/api.py
@@ -21,11 +21,23 @@ from .browser import scenario_report, scenario_sweep
 
 
 def create_app() -> FastAPI:
-    app = FastAPI(title="Datacenter Twin Lab", version=__version__, docs_url=None, redoc_url=None,
-                  description="Local synthetic calculations. No physical controls or persisted mutations.")
-    app.add_middleware(TrustedHostMiddleware, allowed_hosts=["localhost", "127.0.0.1", "[::1]", "testserver"])
-    app.add_middleware(CORSMiddleware, allow_origins=["http://127.0.0.1:5173", "http://localhost:5173"],
-                       allow_methods=["GET", "POST"], allow_headers=["Content-Type"])
+    app = FastAPI(
+        title="Datacenter Twin Lab",
+        version=__version__,
+        docs_url=None,
+        redoc_url=None,
+        description="Local synthetic calculations. No physical controls or persisted mutations.",
+    )
+    app.add_middleware(
+        TrustedHostMiddleware,
+        allowed_hosts=["localhost", "127.0.0.1", "[::1]", "testserver"],
+    )
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["http://127.0.0.1:5173", "http://localhost:5173"],
+        allow_methods=["GET", "POST"],
+        allow_headers=["Content-Type"],
+    )
     slots = asyncio.Semaphore(2)
 
     @app.middleware("http")
@@ -33,7 +45,11 @@ def create_app() -> FastAPI:
         response = await call_next(request)
         response.headers["X-Content-Type-Options"] = "nosniff"
         response.headers["Referrer-Policy"] = "no-referrer"
-        response.headers["Content-Security-Policy"] = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'none'"
+        response.headers["Content-Security-Policy"] = (
+            "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; "
+            "img-src 'self' data:; connect-src 'self'; "
+            "frame-ancestors 'none'; base-uri 'none'"
+        )
         if request.url.path.startswith("/api/"):
             response.headers["Cache-Control"] = "no-store"
         return response
@@ -55,17 +71,25 @@ def create_app() -> FastAPI:
 
     @app.get("/api/v1/health")
     def health():
-        return {"status":"ok", "version":__version__, "mode":"SIMULATED", "scope":"local_stateless"}
+        return {
+            "status": "ok",
+            "version": __version__,
+            "mode": "SIMULATED",
+            "scope": "local_stateless",
+        }
 
     @app.get("/api/v1/presets")
     def presets():
-        return [{"id":key,"name":name} for key,name in PRESETS.items()]
+        return [{"id": key, "name": name} for key, name in PRESETS.items()]
 
     @app.get("/api/v1/demo")
     def demo(preset: str = "utility_loss"):
         return demo_scenario(preset).to_dict()
 
-    @app.post("/api/v1/simulations", summary="Calculate a schema-v2 scenario without persisting or actuating anything")
+    @app.post(
+        "/api/v1/simulations",
+        summary="Calculate a schema-v2 scenario without persisting or actuating anything",
+    )
     async def run(request: Request):
         scenario = SiteScenario.from_dict(await payload(request))
         async with slots:
@@ -92,7 +116,10 @@ def create_app() -> FastAPI:
         async with slots:
             return await run_in_threadpool(scenario_sweep, data)
 
-    @app.post("/api/v1/quotes/normalize", summary="Normalize an assumed rate using the selected offering's declared billing unit")
+    @app.post(
+        "/api/v1/quotes/normalize",
+        summary="Normalize an assumed rate using the selected offering's declared billing unit",
+    )
     async def quote(request: Request):
         return normalize_quote(await payload(request))
 
@@ -102,5 +129,12 @@ def create_app() -> FastAPI:
     else:
         @app.get("/")
         def build_required():
-            return JSONResponse(status_code=503, content={"error":"Dashboard is not built. Run npm ci and npm run build in apps/web."})
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": (
+                        "Dashboard is not built. Run npm ci and npm run build in apps/web."
+                    )
+                },
+            )
     return app

--- a/datacenter_twin/browser.py
+++ b/datacenter_twin/browser.py
@@ -7,7 +7,8 @@ import json
 from urllib.parse import parse_qs, urlsplit
 
 from .catalog import load_catalog, normalize_quote
-from .contracts import InputError, MAX_SCENARIO_BYTES, parse_json_document
+from .contracts import InputError, MAX_SCENARIO_BYTES, Scenario, parse_json_document
+from .engine import simulate as simulate_planning
 from .continuity import simulate_continuity
 from .demo import PRESETS, demo_scenario
 from .topology import SiteScenario
@@ -44,10 +45,12 @@ def dispatch_json(path: str, body: str = "null") -> str:
         result = demo_scenario(preset).to_dict()
     elif route.path == "catalog":
         result = load_catalog()
-    elif route.path in ("simulations", "quotes/normalize", "reports", "sweeps"):
+    elif route.path in ("simulations", "quotes/normalize", "reports", "sweeps", "planning"):
         payload = parse_json_document(body.encode("utf-8"))
         if route.path == "simulations":
             result = simulate_continuity(SiteScenario.from_dict(payload)).to_dict()
+        elif route.path == "planning":
+            result = simulate_planning(Scenario.from_dict(payload))
         elif route.path == "quotes/normalize":
             result = normalize_quote(payload)
         elif route.path == "reports":

--- a/datacenter_twin/catalog.py
+++ b/datacenter_twin/catalog.py
@@ -10,7 +10,8 @@ from .topology import bounded_integer
 
 
 def load_catalog() -> dict:
-    return json.loads(files("datacenter_twin").joinpath("resources/catalog.json").read_text(encoding="utf-8"))
+    resource = files("datacenter_twin").joinpath("resources/catalog.json")
+    return json.loads(resource.read_text(encoding="utf-8"))
 
 
 def normalize_quote(data: dict) -> dict:
@@ -22,22 +23,50 @@ def normalize_quote(data: dict) -> dict:
         raise InputError("offer_id: unknown catalogue offer")
     count = bounded_integer(data["node_count"], "node_count", 1, 100000)
     hours = number(data["billed_hours"], "billed_hours")
-    rate = None if data["assumed_rate"] is None else number(data["assumed_rate"], "assumed_rate")
+    rate = (
+        None
+        if data["assumed_rate"] is None
+        else number(data["assumed_rate"], "assumed_rate")
+    )
     with localcontext(ARITHMETIC):
         node_hours = count * hours
-        units = node_hours * (offer["gpu_count"] if offer["billing_unit"] == "gpu_hour" else 1)
+        billing_multiplier = (
+            offer["gpu_count"] if offer["billing_unit"] == "gpu_hour" else 1
+        )
+        units = node_hours * billing_multiplier
         total = None if rate is None else units * rate
-        node_rate = None if rate is None else rate * (offer["gpu_count"] if offer["billing_unit"] == "gpu_hour" else 1)
+        node_rate = None if rate is None else rate * billing_multiplier
         gpu_rate = None if node_rate is None else node_rate / offer["gpu_count"]
-        return {"offer": offer, "inputs": {"offer_id": offer_id, "node_count": count,
-                "billed_hours": decimal_text(hours), "assumed_rate": None if rate is None else decimal_text(rate)},
-                "billing_unit": offer["billing_unit"], "billed_units": decimal_text(units),
-                "billed_node_hours": decimal_text(node_hours),
-                "normalized_node_hour_rate": None if node_rate is None else decimal_text(node_rate),
-                "provisioned_gpu_hour_rate": None if gpu_rate is None else decimal_text(gpu_rate),
-                "cost": None if total is None else format(total.quantize(Decimal("0.01")), "f"),
-                "currency": offer["currency"], "price_status": "unknown" if rate is None else "user_assumption",
-                "source_ids": offer["source_ids"], "calibrated": False,
-                "limitations": ["User-entered rate is an assumption, not a fetched vendor quote.",
-                    "Already-billed hours exclude invoice granularity, minimums, taxes and ancillary charges.",
-                    "No workload throughput, utilization, region availability or performance equivalence is inferred."]}
+        inputs = {
+            "offer_id": offer_id,
+            "node_count": count,
+            "billed_hours": decimal_text(hours),
+            "assumed_rate": None if rate is None else decimal_text(rate),
+        }
+        limitations = [
+            "User-entered rate is an assumption, not a fetched vendor quote.",
+            "Already-billed hours exclude invoice granularity, minimums, taxes and ancillary charges.",
+            (
+                "No workload throughput, utilization, region availability or "
+                "performance equivalence is inferred."
+            ),
+        ]
+        return {
+            "offer": offer,
+            "inputs": inputs,
+            "billing_unit": offer["billing_unit"],
+            "billed_units": decimal_text(units),
+            "billed_node_hours": decimal_text(node_hours),
+            "normalized_node_hour_rate": (
+                None if node_rate is None else decimal_text(node_rate)
+            ),
+            "provisioned_gpu_hour_rate": (
+                None if gpu_rate is None else decimal_text(gpu_rate)
+            ),
+            "cost": None if total is None else format(total.quantize(Decimal("0.01")), "f"),
+            "currency": offer["currency"],
+            "price_status": "unknown" if rate is None else "user_assumption",
+            "source_ids": offer["source_ids"],
+            "calibrated": False,
+            "limitations": limitations,
+        }

--- a/datacenter_twin/cli.py
+++ b/datacenter_twin/cli.py
@@ -8,6 +8,7 @@ import sys
 
 from . import __version__
 from .contracts import InputError, load_json_document, load_scenario
+from .demo import PRESETS
 from .engine import compare, simulate
 from .output import write_result
 from .reporting import render_html, render_markdown
@@ -25,15 +26,28 @@ def main(argv: list[str] | None = None) -> int:
     continuity = commands.add_parser("simulate", help="Run a schema-v2 electrical continuity scenario")
     source = continuity.add_mutually_exclusive_group()
     source.add_argument("--scenario", type=Path)
-    source.add_argument("--preset", default="utility_loss", choices=["normal","utility_loss","generator_failure","path_maintenance","shared_domain"])
+    source.add_argument("--preset", default="utility_loss", choices=tuple(PRESETS))
     continuity.add_argument("--format", choices=["json", "markdown", "html"], default="json")
     sweep = commands.add_parser("sweep", help="Sweep one field of a schema-v2 electrical continuity scenario")
     sweep_source = sweep.add_mutually_exclusive_group()
     sweep_source.add_argument("--scenario", type=Path)
-    sweep_source.add_argument("--preset", default="generator_failure", choices=["normal", "utility_loss", "generator_failure", "path_maintenance", "shared_domain"])
-    sweep.add_argument("--parameter", required=True, choices=["battery_initial_kwh", "it_demand_kw",
-                                                                "generator_start_delay_s", "distribution_efficiency"])
-    sweep.add_argument("--values", nargs="+", required=True, help="One to twenty decimal values in caller order")
+    sweep_source.add_argument("--preset", default="generator_failure", choices=tuple(PRESETS))
+    sweep.add_argument(
+        "--parameter",
+        required=True,
+        choices=[
+            "battery_initial_kwh",
+            "it_demand_kw",
+            "generator_start_delay_s",
+            "distribution_efficiency",
+        ],
+    )
+    sweep.add_argument(
+        "--values",
+        nargs="+",
+        required=True,
+        help="One to twenty decimal values in caller order",
+    )
     sweep.add_argument("--format", choices=["json", "markdown", "html"], default="json")
     serve = commands.add_parser("serve", help="Serve the local API and built dashboard on loopback")
     serve.add_argument("--port", type=int, default=8000)
@@ -65,7 +79,11 @@ def main(argv: list[str] | None = None) -> int:
             from .demo import demo_scenario
             from .topology import SiteScenario
             input_paths = [args.scenario] if args.scenario else []
-            scenario = SiteScenario.from_dict(load_json_document(args.scenario)) if args.scenario else demo_scenario(args.preset)
+            scenario = (
+                SiteScenario.from_dict(load_json_document(args.scenario))
+                if args.scenario
+                else demo_scenario(args.preset)
+            )
             result = simulate_continuity(scenario).to_dict()
             if args.format == "markdown":
                 content = render_markdown(result)
@@ -79,7 +97,11 @@ def main(argv: list[str] | None = None) -> int:
             from .sensitivity import sweep_continuity
             from .topology import SiteScenario
             input_paths = [args.scenario] if args.scenario else []
-            scenario = SiteScenario.from_dict(load_json_document(args.scenario)) if args.scenario else demo_scenario(args.preset)
+            scenario = (
+                SiteScenario.from_dict(load_json_document(args.scenario))
+                if args.scenario
+                else demo_scenario(args.preset)
+            )
             result = sweep_continuity(scenario, args.parameter, args.values)
             if args.format == "markdown":
                 content = render_markdown(result)

--- a/datacenter_twin/continuity.py
+++ b/datacenter_twin/continuity.py
@@ -1,9 +1,15 @@
-"""Deterministic max-flow dispatch and exact rational energy accounting."""
+"""Deterministic max-flow dispatch and exact rational energy accounting.
+
+The simulator keeps the electrical model deliberately small: one IT load,
+explicit source paths, a finite battery, and a delayed generator.  The helper
+phases below make the event, dispatch, boundary, and accounting decisions
+visible without changing the model's deterministic ordering.
+"""
 
 from collections import deque
 from dataclasses import dataclass
 from decimal import Decimal, localcontext
-from fractions import Fraction as F
+from fractions import Fraction
 import hashlib
 import json
 
@@ -13,55 +19,83 @@ from .engine import ARITHMETIC
 from .topology import SiteScenario, topological_order
 
 
-def text(value: F) -> str:
+def format_quantity(value: Fraction) -> str:
+    """Format an exact rational quantity with the shared decimal context."""
     with localcontext(ARITHMETIC):
         return decimal_text(Decimal(value.numerator) / Decimal(value.denominator))
 
 
-def money(value: F | None) -> str | None:
+def format_currency(value: Fraction | None) -> str | None:
+    """Format an optional exact currency amount to two decimal places."""
     if value is None:
         return None
     with localcontext(ARITHMETIC):
-        return format((Decimal(value.numerator) / Decimal(value.denominator)).quantize(Decimal("0.01")), ".2f")
+        decimal_value = Decimal(value.numerator) / Decimal(value.denominator)
+        return format(decimal_value.quantize(Decimal("0.01")), ".2f")
+
+
+def text(value: Fraction) -> str:
+    """Preserve the historical quantity-formatting import for callers."""
+    return format_quantity(value)
+
+
+def money(value: Fraction | None) -> str | None:
+    """Preserve the historical currency-formatting import for callers."""
+    return format_currency(value)
 
 
 class FlowNetwork:
+    """Small deterministic residual network used for source dispatch."""
+
     def __init__(self):
         self.residual = {}
         self.capacity = {}
 
     def add(self, source, target, capacity):
         self.residual.setdefault(source, {})[target] = capacity
-        self.residual.setdefault(target, {})[source] = F(0)
+        self.residual.setdefault(target, {})[source] = Fraction(0)
         self.capacity[(source, target)] = capacity
 
     def flow(self, source, target):
         return self.capacity[(source, target)] - self.residual[source][target]
 
     def augment(self):
+        """Apply sorted breadth-first augmentations until no path remains."""
         while True:
-            parents = {"SOURCE": None}
-            queue = deque(["SOURCE"])
-            while queue and "SINK" not in parents:
-                current = queue.popleft()
-                for target in sorted(self.residual[current]):
-                    if target not in parents and self.residual[current][target] > 0:
-                        parents[target] = current
-                        queue.append(target)
-            if "SINK" not in parents:
+            parents = self._find_augmenting_path()
+            if parents is None:
                 return
-            current, amount = "SINK", None
-            while parents[current] is not None:
-                previous = parents[current]
-                value = self.residual[previous][current]
-                amount = value if amount is None else min(amount, value)
-                current = previous
-            current = "SINK"
-            while parents[current] is not None:
-                previous = parents[current]
-                self.residual[previous][current] -= amount
-                self.residual[current][previous] += amount
-                current = previous
+            amount = self._capacity_from_parents(parents)
+            self._apply_augmentation(parents, amount)
+
+    def _find_augmenting_path(self):
+        parents = {"SOURCE": None}
+        queue = deque(["SOURCE"])
+        while queue and "SINK" not in parents:
+            current = queue.popleft()
+            for target in sorted(self.residual[current]):
+                if target not in parents and self.residual[current][target] > 0:
+                    parents[target] = current
+                    queue.append(target)
+        return parents if "SINK" in parents else None
+
+    def _capacity_from_parents(self, parents):
+        current = "SINK"
+        amount = None
+        while parents[current] is not None:
+            previous = parents[current]
+            edge_capacity = self.residual[previous][current]
+            amount = edge_capacity if amount is None else min(amount, edge_capacity)
+            current = previous
+        return amount
+
+    def _apply_augmentation(self, parents, amount):
+        current = "SINK"
+        while parents[current] is not None:
+            previous = parents[current]
+            self.residual[previous][current] -= amount
+            self.residual[current][previous] += amount
+            current = previous
 
 
 @dataclass(frozen=True)
@@ -74,155 +108,703 @@ class SimulationRun:
     summary: dict
 
     def to_dict(self):
-        return {"schema_version": 2, "model": "single_load_electrical_continuity_v1",
-                "engine_version": __version__, "run_id": self.run_id, "input_sha256": self.input_sha256,
-                "mode": "SIMULATED", "quality": "synthetic_uncalibrated", "scenario": self.scenario.to_dict(),
-                "intervals": list(self.intervals), "events": list(self.events), "summary": self.summary,
-                "boundary": "Electrical supply, stored battery energy, conversion losses and served IT; cooling excluded",
-                "limitations": ["No switching transient, protection study, cooling, workload queue or certification model.",
-                                "Generator starts on utility-asset unavailability only; downstream path faults do not request a start.",
-                                "Generator fuel is assumed sufficient for this horizon; its unit energy cost may be unknown.",
-                                "Initial stored battery energy is an opening balance; prior charging cost is excluded.",
-                                "Prices are illustrative inputs; costs exclude CAPEX and non-energy charges."]}
+        return {
+            "schema_version": 2,
+            "model": "single_load_electrical_continuity_v1",
+            "engine_version": __version__,
+            "run_id": self.run_id,
+            "input_sha256": self.input_sha256,
+            "mode": "SIMULATED",
+            "quality": "synthetic_uncalibrated",
+            "scenario": self.scenario.to_dict(),
+            "intervals": list(self.intervals),
+            "events": list(self.events),
+            "summary": self.summary,
+            "boundary": (
+                "Electrical supply, stored battery energy, conversion losses and served IT; "
+                "cooling excluded"
+            ),
+            "limitations": [
+                "No switching transient, protection study, cooling, workload queue or certification model.",
+                "Generator starts on utility-asset unavailability only; downstream path faults "
+                "do not request a start.",
+                "Generator fuel is assumed sufficient for this horizon; its unit energy cost may be unknown.",
+                "Initial stored battery energy is an opening balance; prior charging cost is excluded.",
+                "Prices are illustrative inputs; costs exclude CAPEX and non-energy charges.",
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class _SimulationSetup:
+    assets: dict
+    utility_id: str
+    generator_id: str
+    battery_id: str
+    load_id: str
+    requires_order: list[str]
+    incoming_requires: dict[str, list[str]]
+    schedule: list[tuple[int, object]]
+
+
+@dataclass
+class _SimulationState:
+    now: Fraction
+    demand_kw: Fraction
+    stored_energy_kwh: Fraction
+    event_index: int
+    direct_down: set[str]
+    domains_down: set[str]
+    generator_ready_at: Fraction | None
+    rows: list[dict]
+    event_log: list[dict]
+    totals: dict[str, Fraction]
+    peak_unserved_kw: Fraction
+
+
+@dataclass(frozen=True)
+class _DispatchResult:
+    network: FlowNetwork
+    gross_load_kw: Fraction
+    grid_kw: Fraction
+    generator_kw: Fraction
+    battery_kw: Fraction
+    charging_kw: Fraction
+
+
+@dataclass(frozen=True)
+class _IntervalAccounting:
+    boundary: Fraction
+    seconds: Fraction
+    hours: Fraction
+    stored_energy_kwh: Fraction
+    served_kw: Fraction
+    unserved_kw: Fraction
+    values: dict[str, Fraction]
+
+
+def _prepare_simulation(scenario: SiteScenario):
+    canonical = json.dumps(scenario.to_dict(), sort_keys=True, separators=(",", ":"))
+    input_sha256 = hashlib.sha256(canonical.encode()).hexdigest()
+    run_id = hashlib.sha256(
+        f"continuity-v1:{__version__}:{input_sha256}".encode()
+    ).hexdigest()[:20]
+
+    assets = {asset.id: asset for asset in scenario.assets}
+    asset_by_kind = {
+        kind: next(asset.id for asset in scenario.assets if asset.kind == kind)
+        for kind in ("utility", "generator", "battery", "load")
+    }
+    requires_order = topological_order(scenario.assets, scenario.dependencies, "requires")
+    incoming_requires = {
+        asset_id: [
+            edge.source
+            for edge in scenario.dependencies
+            if edge.target == asset_id and edge.relation == "requires"
+        ]
+        for asset_id in assets
+    }
+    schedule = sorted(
+        enumerate(scenario.events), key=lambda pair: (pair[1].at_s, pair[0])
+    )
+    setup = _SimulationSetup(
+        assets=assets,
+        utility_id=asset_by_kind["utility"],
+        generator_id=asset_by_kind["generator"],
+        battery_id=asset_by_kind["battery"],
+        load_id=asset_by_kind["load"],
+        requires_order=requires_order,
+        incoming_requires=incoming_requires,
+        schedule=schedule,
+    )
+    return setup, input_sha256, run_id
+
+
+def _new_simulation_state(scenario: SiteScenario) -> _SimulationState:
+    total_keys = (
+        "requested_it_kwh",
+        "served_it_kwh",
+        "unserved_it_kwh",
+        "grid_kwh",
+        "generator_kwh",
+        "distribution_loss_kwh",
+        "battery_charge_loss_kwh",
+        "battery_discharge_loss_kwh",
+        "battery_stored_change_kwh",
+        "unserved_duration_s",
+    )
+    return _SimulationState(
+        now=Fraction(0),
+        demand_kw=Fraction(scenario.it_demand_kw),
+        stored_energy_kwh=Fraction(scenario.battery_initial_kwh),
+        event_index=0,
+        direct_down=set(),
+        domains_down=set(),
+        generator_ready_at=None,
+        rows=[],
+        event_log=[],
+        totals={key: Fraction(0) for key in total_keys},
+        peak_unserved_kw=Fraction(0),
+    )
+
+
+def _apply_events_at_current_time(
+    state: _SimulationState,
+    setup: _SimulationSetup,
+) -> None:
+    """Apply same-time events by original sequence, retaining deterministic order."""
+    while (
+        state.event_index < len(setup.schedule)
+        and setup.schedule[state.event_index][1].at_s == state.now
+    ):
+        sequence, event = setup.schedule[state.event_index]
+        if event.action == "asset_down":
+            state.direct_down.add(event.target)
+        elif event.action == "asset_up":
+            state.direct_down.discard(event.target)
+        elif event.action == "domain_down":
+            state.domains_down.add(event.target)
+        elif event.action == "domain_up":
+            state.domains_down.discard(event.target)
+        else:
+            state.demand_kw = Fraction(event.value_kw)
+        state.event_log.append(
+            {
+                **event.to_dict(),
+                "at_s": format_quantity(Fraction(event.at_s)),
+                "sequence": sequence,
+                "origin": "scenario_event",
+            }
+        )
+        state.event_index += 1
+
+
+def _calculate_availability(
+    state: _SimulationState,
+    setup: _SimulationSetup,
+) -> dict[str, bool]:
+    """Propagate direct and failure-domain outages through requires edges."""
+    available = {}
+    for asset_id in setup.requires_order:
+        asset = setup.assets[asset_id]
+        direct_failure = asset_id in state.direct_down
+        domain_failure = bool(state.domains_down.intersection(asset.failure_domains))
+        dependencies_available = all(
+            available[source] for source in setup.incoming_requires[asset_id]
+        )
+        available[asset_id] = not direct_failure and not domain_failure and dependencies_available
+    return available
+
+
+def _update_generator_readiness(
+    state: _SimulationState,
+    scenario: SiteScenario,
+    setup: _SimulationSetup,
+    available: dict[str, bool],
+) -> bool:
+    """Request a start only for utility loss and expose the current running state."""
+    utility_available = available[setup.utility_id]
+    generator_available = available[setup.generator_id]
+    if utility_available or not generator_available:
+        state.generator_ready_at = None
+    elif state.generator_ready_at is None:
+        state.generator_ready_at = state.now + scenario.generator_start_delay_s
+        state.event_log.append(
+            {
+                "at_s": format_quantity(state.now),
+                "action": "generator_start_requested",
+                "target": setup.generator_id,
+                "ready_at_s": format_quantity(state.generator_ready_at),
+                "origin": "simulation",
+            }
+        )
+    return (
+        state.generator_ready_at is not None
+        and state.now >= state.generator_ready_at
+        and generator_available
+    )
+
+
+def _build_dispatch_network(
+    scenario: SiteScenario,
+    setup: _SimulationSetup,
+    available: dict[str, bool],
+    demand_kw: Fraction,
+    distribution_efficiency: Fraction,
+) -> FlowNetwork:
+    network = FlowNetwork()
+    total_capacity_kw = sum(
+        (Fraction(asset.capacity_kw) for asset in setup.assets.values()), Fraction(0)
+    )
+    for asset_id in sorted(setup.assets):
+        capacity_kw = (
+            Fraction(setup.assets[asset_id].capacity_kw) if available[asset_id] else Fraction(0)
+        )
+        network.add(f"in:{asset_id}", f"out:{asset_id}", capacity_kw)
+    for edge in sorted(
+        scenario.dependencies,
+        key=lambda dependency: (
+            dependency.source,
+            dependency.target,
+            dependency.relation,
+        ),
+    ):
+        if edge.relation == "feeds":
+            network.add(
+                f"out:{edge.source}", f"in:{edge.target}", total_capacity_kw
+            )
+    network.add(
+        f"out:{setup.load_id}", "SINK", demand_kw / distribution_efficiency
+    )
+    return network
+
+
+def _dispatch_sources(
+    network: FlowNetwork,
+    setup: _SimulationSetup,
+    available: dict[str, bool],
+    generator_running: bool,
+    stored_energy_kwh: Fraction,
+) -> None:
+    """Add and augment sources in utility, generator, battery priority order."""
+    sources = (
+        (setup.utility_id, available[setup.utility_id]),
+        (setup.generator_id, generator_running),
+        (setup.battery_id, stored_energy_kwh > 0 and available[setup.battery_id]),
+    )
+    for source_id, enabled in sources:
+        source_capacity_kw = (
+            Fraction(setup.assets[source_id].capacity_kw) if enabled else Fraction(0)
+        )
+        network.add("SOURCE", f"in:{source_id}", source_capacity_kw)
+        # Incremental augmentation preserves source priority while allowing
+        # residual rerouting around a saturated path.
+        network.augment()
+
+
+def _dispatch_charging(
+    network: FlowNetwork,
+    scenario: SiteScenario,
+    setup: _SimulationSetup,
+    available: dict[str, bool],
+    generator_kw: Fraction,
+    battery_kw: Fraction,
+    stored_energy_kwh: Fraction,
+    capacity_kwh: Fraction,
+) -> Fraction:
+    """Use only spare utility capacity for charging, never circulating battery flow."""
+    can_charge = (
+        battery_kw == 0
+        and generator_kw == 0
+        and available[setup.utility_id]
+        and available[setup.battery_id]
+        and stored_energy_kwh < capacity_kwh
+    )
+    if not can_charge:
+        return Fraction(0)
+
+    for source_id in (setup.generator_id, setup.battery_id):
+        network.residual["SOURCE"][f"in:{source_id}"] = Fraction(0)
+        network.capacity[("SOURCE", f"in:{source_id}")] = Fraction(0)
+    charging_edge = next(
+        edge for edge in scenario.dependencies if edge.relation == "charges"
+    )
+    network.add(
+        f"out:{charging_edge.source}",
+        "CHARGER",
+        Fraction(scenario.battery_charge_kw),
+    )
+    network.add("CHARGER", "SINK", Fraction(scenario.battery_charge_kw))
+    network.augment()
+    return network.flow("CHARGER", "SINK")
+
+
+def _dispatch_interval(
+    scenario: SiteScenario,
+    setup: _SimulationSetup,
+    available: dict[str, bool],
+    generator_running: bool,
+    demand_kw: Fraction,
+    stored_energy_kwh: Fraction,
+    capacity_kwh: Fraction,
+    distribution_efficiency: Fraction,
+) -> _DispatchResult:
+    network = _build_dispatch_network(
+        scenario, setup, available, demand_kw, distribution_efficiency
+    )
+    _dispatch_sources(
+        network,
+        setup,
+        available,
+        generator_running,
+        stored_energy_kwh,
+    )
+    gross_load_kw = network.flow(f"out:{setup.load_id}", "SINK")
+    battery_kw = network.flow("SOURCE", f"in:{setup.battery_id}")
+    generator_kw = network.flow("SOURCE", f"in:{setup.generator_id}")
+    charging_kw = _dispatch_charging(
+        network,
+        scenario,
+        setup,
+        available,
+        generator_kw,
+        battery_kw,
+        stored_energy_kwh,
+        capacity_kwh,
+    )
+    # Charging augmentation may consume spare utility flow, so read grid
+    # dispatch after that phase has finished.
+    grid_kw = network.flow("SOURCE", f"in:{setup.utility_id}")
+    return _DispatchResult(
+        network=network,
+        gross_load_kw=gross_load_kw,
+        grid_kw=grid_kw,
+        generator_kw=generator_kw,
+        battery_kw=battery_kw,
+        charging_kw=charging_kw,
+    )
+
+
+def _next_interval_boundary(
+    state: _SimulationState,
+    scenario: SiteScenario,
+    setup: _SimulationSetup,
+    battery_kw: Fraction,
+    charging_kw: Fraction,
+    charge_efficiency: Fraction,
+    discharge_efficiency: Fraction,
+    capacity_kwh: Fraction,
+) -> Fraction:
+    """Choose the earliest regular, event, generator, full, or empty boundary."""
+    boundary = min(
+        state.now + scenario.step_s,
+        Fraction(scenario.duration_s),
+    )
+    if state.event_index < len(setup.schedule):
+        next_event_at = Fraction(setup.schedule[state.event_index][1].at_s)
+        boundary = min(boundary, next_event_at)
+    if state.generator_ready_at is not None and state.generator_ready_at > state.now:
+        boundary = min(boundary, state.generator_ready_at)
+    if battery_kw:
+        battery_empty_at = (
+            state.now + state.stored_energy_kwh * discharge_efficiency / battery_kw * 3600
+        )
+        boundary = min(boundary, battery_empty_at)
+    if charging_kw:
+        battery_full_at = (
+            state.now
+            + (capacity_kwh - state.stored_energy_kwh)
+            / (charging_kw * charge_efficiency)
+            * 3600
+        )
+        boundary = min(boundary, battery_full_at)
+    return boundary
+
+
+def _calculate_interval_accounting(
+    state: _SimulationState,
+    dispatch: _DispatchResult,
+    boundary: Fraction,
+    distribution_efficiency: Fraction,
+    charge_efficiency: Fraction,
+    discharge_efficiency: Fraction,
+    capacity_kwh: Fraction,
+) -> _IntervalAccounting:
+    seconds = boundary - state.now
+    if seconds <= 0:
+        raise RuntimeError("Non-progressing simulation boundary")
+    hours = seconds / 3600
+    previous_energy_kwh = state.stored_energy_kwh
+    battery_out_kwh = dispatch.battery_kw * hours / discharge_efficiency
+    battery_in_kwh = dispatch.charging_kw * hours * charge_efficiency
+    stored_energy_kwh = previous_energy_kwh - battery_out_kwh + battery_in_kwh
+    served_kw = dispatch.gross_load_kw * distribution_efficiency
+    unserved_kw = state.demand_kw - served_kw
+    values = {
+        "requested_it_kwh": state.demand_kw * hours,
+        "served_it_kwh": served_kw * hours,
+        "unserved_it_kwh": unserved_kw * hours,
+        "grid_kwh": dispatch.grid_kw * hours,
+        "generator_kwh": dispatch.generator_kw * hours,
+        "distribution_loss_kwh": (dispatch.gross_load_kw - served_kw) * hours,
+        "battery_charge_loss_kwh": dispatch.charging_kw * hours - battery_in_kwh,
+        "battery_discharge_loss_kwh": battery_out_kwh - dispatch.battery_kw * hours,
+        "battery_stored_change_kwh": stored_energy_kwh - previous_energy_kwh,
+        "unserved_duration_s": seconds if unserved_kw > 0 else Fraction(0),
+    }
+    # The residual checks source energy against served IT, conversion losses,
+    # and the battery balance before any values are formatted for export.
+    residual = (
+        values["grid_kwh"]
+        + values["generator_kwh"]
+        - values["battery_stored_change_kwh"]
+        - values["served_it_kwh"]
+        - values["distribution_loss_kwh"]
+        - values["battery_charge_loss_kwh"]
+        - values["battery_discharge_loss_kwh"]
+    )
+    if residual or not 0 <= stored_energy_kwh <= capacity_kwh or unserved_kw < 0:
+        raise RuntimeError("Electrical energy invariant violated")
+    return _IntervalAccounting(
+        boundary=boundary,
+        seconds=seconds,
+        hours=hours,
+        stored_energy_kwh=stored_energy_kwh,
+        served_kw=served_kw,
+        unserved_kw=unserved_kw,
+        values=values,
+    )
+
+
+def _accumulate_accounting(
+    state: _SimulationState,
+    accounting: _IntervalAccounting,
+) -> None:
+    for key, value in accounting.values.items():
+        state.totals[key] += value
+    state.peak_unserved_kw = max(state.peak_unserved_kw, accounting.unserved_kw)
+
+
+def _interval_warnings(
+    state: _SimulationState,
+    scenario: SiteScenario,
+    setup: _SimulationSetup,
+    available: dict[str, bool],
+    accounting: _IntervalAccounting,
+) -> list[str]:
+    warnings = []
+    if accounting.unserved_kw > 0:
+        warnings.append("UNSERVED_IT_LOAD")
+    if state.demand_kw > Fraction(scenario.it_capacity_kw):
+        warnings.append("IT_ENVELOPE_EXCEEDED")
+    if not available[setup.utility_id]:
+        warnings.append("UTILITY_UNAVAILABLE")
+    if accounting.stored_energy_kwh == 0:
+        warnings.append("BATTERY_EMPTY")
+    if state.domains_down:
+        warnings.append("SHARED_DOMAIN_OUTAGE")
+    return warnings
+
+
+def _asset_states(
+    state: _SimulationState,
+    setup: _SimulationSetup,
+    available: dict[str, bool],
+    generator_running: bool,
+    dispatch: _DispatchResult,
+    accounting: _IntervalAccounting,
+) -> dict[str, str]:
+    asset_states = {
+        asset_id: "available" if available[asset_id] else "unavailable"
+        for asset_id in setup.assets
+    }
+    if available[setup.generator_id]:
+        asset_states[setup.generator_id] = (
+            "running"
+            if generator_running
+            else "starting"
+            if state.generator_ready_at is not None
+            else "standby"
+        )
+    if available[setup.battery_id]:
+        asset_states[setup.battery_id] = (
+            "discharging"
+            if dispatch.battery_kw
+            else "charging"
+            if dispatch.charging_kw
+            else "empty"
+            if accounting.stored_energy_kwh == 0
+            else "ready"
+        )
+    if available[setup.load_id]:
+        asset_states[setup.load_id] = (
+            "unserved"
+            if accounting.served_kw == 0 and state.demand_kw > 0
+            else "degraded"
+            if accounting.unserved_kw
+            else "served"
+        )
+    return asset_states
+
+
+def _build_interval_row(
+    state: _SimulationState,
+    scenario: SiteScenario,
+    setup: _SimulationSetup,
+    available: dict[str, bool],
+    dispatch: _DispatchResult,
+    accounting: _IntervalAccounting,
+    generator_running: bool,
+) -> dict:
+    _accumulate_accounting(state, accounting)
+    asset_states = _asset_states(
+        state, setup, available, generator_running, dispatch, accounting
+    )
+    warnings = _interval_warnings(state, scenario, setup, available, accounting)
+    values = accounting.values
+    previous_energy_kwh = state.stored_energy_kwh
+    feed_flows = [
+        {
+            "source": edge.source,
+            "target": edge.target,
+            "kw": format_quantity(
+                dispatch.network.flow(f"out:{edge.source}", f"in:{edge.target}")
+            ),
+        }
+        for edge in scenario.dependencies
+        if edge.relation == "feeds"
+    ]
+    return {
+        "start_s": format_quantity(state.now),
+        "end_s": format_quantity(accounting.boundary),
+        "duration_s": format_quantity(accounting.seconds),
+        "requested_it_kw": format_quantity(state.demand_kw),
+        "served_it_kw": format_quantity(accounting.served_kw),
+        "unserved_it_kw": format_quantity(accounting.unserved_kw),
+        "electrical_source_kw": format_quantity(
+            dispatch.grid_kw + dispatch.generator_kw + dispatch.battery_kw
+        ),
+        "grid_kw": format_quantity(dispatch.grid_kw),
+        "generator_kw": format_quantity(dispatch.generator_kw),
+        "battery_discharge_kw": format_quantity(dispatch.battery_kw),
+        "battery_charge_kw": format_quantity(dispatch.charging_kw),
+        "battery_start_kwh": format_quantity(previous_energy_kwh),
+        "battery_end_kwh": format_quantity(accounting.stored_energy_kwh),
+        "it_capacity_margin_kw": format_quantity(
+            Fraction(scenario.it_capacity_kw) - state.demand_kw
+        ),
+        "grid_energy_charge_to_date": format_currency(
+            None
+            if scenario.tariff_per_kwh is None
+            else state.totals["grid_kwh"] * Fraction(scenario.tariff_per_kwh)
+        ),
+        "energy": {key: format_quantity(value) for key, value in values.items()},
+        "energy_balance_residual_kwh": "0",
+        "asset_states": asset_states,
+        "warnings": warnings,
+        "feed_flows_kw": feed_flows,
+    }
+
+
+def _build_summary(
+    scenario: SiteScenario,
+    state: _SimulationState,
+) -> dict:
+    grid_cost = (
+        None
+        if scenario.tariff_per_kwh is None
+        else state.totals["grid_kwh"] * Fraction(scenario.tariff_per_kwh)
+    )
+    if state.totals["generator_kwh"] == 0:
+        generator_cost = Fraction(0)
+    elif scenario.generator_cost_per_kwh is None:
+        generator_cost = None
+    else:
+        generator_cost = state.totals["generator_kwh"] * Fraction(
+            scenario.generator_cost_per_kwh
+        )
+    return {
+        **{key: format_quantity(value) for key, value in state.totals.items()},
+        "battery_final_kwh": format_quantity(state.stored_energy_kwh),
+        "peak_unserved_kw": format_quantity(state.peak_unserved_kw),
+        "energy_balance_residual_kwh": "0",
+        "grid_energy_charge": format_currency(grid_cost),
+        "generator_energy_charge": format_currency(generator_cost),
+        "total_incremental_energy_charge": format_currency(
+            None
+            if grid_cost is None or generator_cost is None
+            else grid_cost + generator_cost
+        ),
+        "cost_status": (
+            "unknown_component"
+            if grid_cost is None or generator_cost is None
+            else "illustrative"
+        ),
+        "service_status": (
+            "unserved_load"
+            if state.totals["unserved_it_kwh"]
+            else "served_throughout"
+        ),
+        "interval_count": len(state.rows),
+    }
 
 
 def simulate_continuity(scenario: SiteScenario) -> SimulationRun:
+    """Simulate a validated single-load electrical continuity scenario."""
     if not isinstance(scenario, SiteScenario):
         raise InputError("Expected a validated SiteScenario")
-    canonical = json.dumps(scenario.to_dict(), sort_keys=True, separators=(",", ":"))
-    digest = hashlib.sha256(canonical.encode()).hexdigest()
-    run_id = hashlib.sha256(f"continuity-v1:{__version__}:{digest}".encode()).hexdigest()[:20]
-    assets = {asset.id: asset for asset in scenario.assets}
-    kinds = {kind: next(a.id for a in scenario.assets if a.kind == kind) for kind in ("utility", "generator", "battery", "load")}
-    utility, generator, battery, load = (kinds[kind] for kind in ("utility", "generator", "battery", "load"))
-    requires_order = topological_order(scenario.assets, scenario.dependencies, "requires")
-    incoming_requires = {asset_id: [edge.source for edge in scenario.dependencies if edge.target == asset_id and edge.relation == "requires"] for asset_id in assets}
-    schedule = sorted(enumerate(scenario.events), key=lambda pair: (pair[1].at_s, pair[0]))
-    direct_down, domains_down = set(), set()
-    index = 0
-    now, demand = F(0), F(scenario.it_demand_kw)
-    energy = F(scenario.battery_initial_kwh)
-    capacity = F(scenario.battery_capacity_kwh)
-    eta, charge_eta, discharge_eta = map(F, (scenario.distribution_efficiency, scenario.battery_charge_efficiency, scenario.battery_discharge_efficiency))
-    ready_at = None
-    rows, log = [], []
-    totals = {key: F(0) for key in ("requested_it_kwh", "served_it_kwh", "unserved_it_kwh", "grid_kwh", "generator_kwh",
-                                    "distribution_loss_kwh", "battery_charge_loss_kwh", "battery_discharge_loss_kwh",
-                                    "battery_stored_change_kwh", "unserved_duration_s")}
-    peak_unserved = F(0)
-    while now < scenario.duration_s:
-        if len(rows) > 5000:
-            raise InputError("Simulation exceeded its interval budget")
-        while index < len(schedule) and schedule[index][1].at_s == now:
-            order, event = schedule[index]
-            if event.action == "asset_down": direct_down.add(event.target)
-            elif event.action == "asset_up": direct_down.discard(event.target)
-            elif event.action == "domain_down": domains_down.add(event.target)
-            elif event.action == "domain_up": domains_down.discard(event.target)
-            else: demand = F(event.value_kw)
-            log.append({**event.to_dict(), "at_s": text(F(event.at_s)), "sequence": order, "origin": "scenario_event"})
-            index += 1
-        available = {}
-        for asset_id in requires_order:
-            asset = assets[asset_id]
-            available[asset_id] = (asset_id not in direct_down and not domains_down.intersection(asset.failure_domains)
-                                   and all(available[source] for source in incoming_requires[asset_id]))
-        if available[utility] or not available[generator]:
-            ready_at = None
-        elif ready_at is None:
-            ready_at = now + scenario.generator_start_delay_s
-            log.append({"at_s": text(now), "action": "generator_start_requested", "target": generator,
-                        "ready_at_s": text(ready_at), "origin": "simulation"})
-        running = ready_at is not None and now >= ready_at and available[generator]
-        boundary = min(now + scenario.step_s, F(scenario.duration_s))
-        if index < len(schedule): boundary = min(boundary, F(schedule[index][1].at_s))
-        if ready_at is not None and ready_at > now: boundary = min(boundary, ready_at)
+    setup, input_sha256, run_id = _prepare_simulation(scenario)
+    state = _new_simulation_state(scenario)
+    distribution_efficiency = Fraction(scenario.distribution_efficiency)
+    charge_efficiency = Fraction(scenario.battery_charge_efficiency)
+    discharge_efficiency = Fraction(scenario.battery_discharge_efficiency)
+    capacity_kwh = Fraction(scenario.battery_capacity_kwh)
 
-        network = FlowNetwork()
-        infinity = sum((F(asset.capacity_kw) for asset in scenario.assets), F(0))
-        for asset_id in sorted(assets):
-            network.add(f"in:{asset_id}", f"out:{asset_id}", F(assets[asset_id].capacity_kw) if available[asset_id] else F(0))
-        for edge in sorted(scenario.dependencies, key=lambda e: (e.source, e.target, e.relation)):
-            if edge.relation == "feeds":
-                network.add(f"out:{edge.source}", f"in:{edge.target}", infinity)
-        network.add(f"out:{load}", "SINK", demand / eta)
-        # Incremental max-flow preserves dispatch priority while allowing residual rerouting.
-        for source, enabled in ((utility, available[utility]), (generator, running), (battery, energy > 0 and available[battery])):
-            network.add("SOURCE", f"in:{source}", F(assets[source].capacity_kw) if enabled else F(0))
-            network.augment()
-        gross_load = network.flow(f"out:{load}", "SINK")
-        battery_kw = network.flow("SOURCE", f"in:{battery}")
-        generator_kw = network.flow("SOURCE", f"in:{generator}")
-        charging_kw = F(0)
-        if battery_kw == 0 and generator_kw == 0 and available[utility] and available[battery] and energy < capacity:
-            # Charge only from spare utility capacity, never by circulating battery energy.
-            for source in (generator, battery):
-                network.residual["SOURCE"][f"in:{source}"] = F(0)
-                network.capacity[("SOURCE", f"in:{source}")] = F(0)
-            charging_edge = next(edge for edge in scenario.dependencies if edge.relation == "charges")
-            network.add(f"out:{charging_edge.source}", "CHARGER", F(scenario.battery_charge_kw))
-            network.add("CHARGER", "SINK", F(scenario.battery_charge_kw))
-            network.augment()
-            charging_kw = network.flow("CHARGER", "SINK")
-        grid_kw = network.flow("SOURCE", f"in:{utility}")
-        if battery_kw:
-            boundary = min(boundary, now + energy * discharge_eta / battery_kw * 3600)
-        if charging_kw:
-            boundary = min(boundary, now + (capacity - energy) / (charging_kw * charge_eta) * 3600)
-        seconds, hours = boundary - now, (boundary - now) / 3600
-        if seconds <= 0:
-            raise RuntimeError("Non-progressing simulation boundary")
-        previous_energy = energy
-        battery_out = battery_kw * hours / discharge_eta
-        battery_in = charging_kw * hours * charge_eta
-        energy = energy - battery_out + battery_in
-        served = gross_load * eta
-        unserved = demand - served
-        values = {"requested_it_kwh": demand * hours, "served_it_kwh": served * hours,
-                  "unserved_it_kwh": unserved * hours, "grid_kwh": grid_kw * hours,
-                  "generator_kwh": generator_kw * hours, "distribution_loss_kwh": (gross_load - served) * hours,
-                  "battery_charge_loss_kwh": charging_kw * hours - battery_in,
-                  "battery_discharge_loss_kwh": battery_out - battery_kw * hours,
-                  "battery_stored_change_kwh": energy - previous_energy,
-                  "unserved_duration_s": seconds if unserved > 0 else F(0)}
-        residual = values["grid_kwh"] + values["generator_kwh"] - values["battery_stored_change_kwh"] - values["served_it_kwh"] - values["distribution_loss_kwh"] - values["battery_charge_loss_kwh"] - values["battery_discharge_loss_kwh"]
-        if residual or not 0 <= energy <= capacity or unserved < 0:
-            raise RuntimeError("Electrical energy invariant violated")
-        for key, value in values.items(): totals[key] += value
-        peak_unserved = max(peak_unserved, unserved)
-        warnings = []
-        if unserved > 0: warnings.append("UNSERVED_IT_LOAD")
-        if demand > F(scenario.it_capacity_kw): warnings.append("IT_ENVELOPE_EXCEEDED")
-        if not available[utility]: warnings.append("UTILITY_UNAVAILABLE")
-        if energy == 0: warnings.append("BATTERY_EMPTY")
-        if domains_down: warnings.append("SHARED_DOMAIN_OUTAGE")
-        asset_states = {asset_id: "available" if available[asset_id] else "unavailable" for asset_id in assets}
-        if available[generator]: asset_states[generator] = "running" if running else "starting" if ready_at is not None else "standby"
-        if available[battery]: asset_states[battery] = "discharging" if battery_kw else "charging" if charging_kw else "empty" if energy == 0 else "ready"
-        if available[load]: asset_states[load] = "unserved" if served == 0 and demand > 0 else "degraded" if unserved else "served"
-        rows.append({"start_s": text(now), "end_s": text(boundary), "duration_s": text(seconds),
-                     "requested_it_kw": text(demand), "served_it_kw": text(served), "unserved_it_kw": text(unserved),
-                     "electrical_source_kw": text(grid_kw + generator_kw + battery_kw),
-                     "grid_kw": text(grid_kw), "generator_kw": text(generator_kw), "battery_discharge_kw": text(battery_kw),
-                     "battery_charge_kw": text(charging_kw), "battery_start_kwh": text(previous_energy), "battery_end_kwh": text(energy),
-                     "it_capacity_margin_kw": text(F(scenario.it_capacity_kw) - demand),
-                     "grid_energy_charge_to_date": money(None if scenario.tariff_per_kwh is None else totals["grid_kwh"] * F(scenario.tariff_per_kwh)),
-                     "energy": {key: text(value) for key, value in values.items()}, "energy_balance_residual_kwh": "0",
-                     "asset_states": asset_states, "warnings": warnings,
-                     "feed_flows_kw": [{"source": edge.source, "target": edge.target,
-                                        "kw": text(network.flow(f"out:{edge.source}", f"in:{edge.target}"))}
-                                       for edge in scenario.dependencies if edge.relation == "feeds"]})
-        if energy == 0 and previous_energy > 0:
-            log.append({"at_s": text(boundary), "action": "battery_depleted", "target": battery, "origin": "simulation"})
-        now = boundary
-    grid_cost = None if scenario.tariff_per_kwh is None else totals["grid_kwh"] * F(scenario.tariff_per_kwh)
-    generator_cost = (F(0) if totals["generator_kwh"] == 0 else None if scenario.generator_cost_per_kwh is None
-                      else totals["generator_kwh"] * F(scenario.generator_cost_per_kwh))
-    summary = {**{key: text(value) for key, value in totals.items()}, "battery_final_kwh": text(energy),
-               "peak_unserved_kw": text(peak_unserved), "energy_balance_residual_kwh": "0",
-               "grid_energy_charge": money(grid_cost), "generator_energy_charge": money(generator_cost),
-               "total_incremental_energy_charge": money(None if grid_cost is None or generator_cost is None else grid_cost + generator_cost),
-               "cost_status": "unknown_component" if grid_cost is None or generator_cost is None else "illustrative",
-               "service_status": "unserved_load" if totals["unserved_it_kwh"] else "served_throughout",
-               "interval_count": len(rows)}
-    return SimulationRun(run_id, digest, scenario, tuple(rows), tuple(log), summary)
+    while state.now < scenario.duration_s:
+        if len(state.rows) > 5000:
+            raise InputError("Simulation exceeded its interval budget")
+        _apply_events_at_current_time(state, setup)
+        available = _calculate_availability(state, setup)
+        generator_running = _update_generator_readiness(
+            state, scenario, setup, available
+        )
+        dispatch = _dispatch_interval(
+            scenario,
+            setup,
+            available,
+            generator_running,
+            state.demand_kw,
+            state.stored_energy_kwh,
+            capacity_kwh,
+            distribution_efficiency,
+        )
+        boundary = _next_interval_boundary(
+            state,
+            scenario,
+            setup,
+            dispatch.battery_kw,
+            dispatch.charging_kw,
+            charge_efficiency,
+            discharge_efficiency,
+            capacity_kwh,
+        )
+        accounting = _calculate_interval_accounting(
+            state,
+            dispatch,
+            boundary,
+            distribution_efficiency,
+            charge_efficiency,
+            discharge_efficiency,
+            capacity_kwh,
+        )
+        state.rows.append(
+            _build_interval_row(
+                state,
+                scenario,
+                setup,
+                available,
+                dispatch,
+                accounting,
+                generator_running,
+            )
+        )
+        if accounting.stored_energy_kwh == 0 and state.stored_energy_kwh > 0:
+            state.event_log.append(
+                {
+                    "at_s": format_quantity(accounting.boundary),
+                    "action": "battery_depleted",
+                    "target": setup.battery_id,
+                    "origin": "simulation",
+                }
+            )
+        state.stored_energy_kwh = accounting.stored_energy_kwh
+        state.now = accounting.boundary
+
+    return SimulationRun(
+        run_id,
+        input_sha256,
+        scenario,
+        tuple(state.rows),
+        tuple(state.event_log),
+        _build_summary(scenario, state),
+    )

--- a/datacenter_twin/contracts.py
+++ b/datacenter_twin/contracts.py
@@ -119,7 +119,11 @@ class Scenario:
             raise InputError("segments: expected at most 10000 Segment instances")
         if any(not isinstance(segment, Segment) for segment in self.segments):
             raise InputError("segments: expected Segment instances; use from_dict for JSON objects")
-        object.__setattr__(self, "it_capacity_kw", number(self.it_capacity_kw, "it_capacity_kw", positive=True))
+        object.__setattr__(
+            self,
+            "it_capacity_kw",
+            number(self.it_capacity_kw, "it_capacity_kw", positive=True),
+        )
         object.__setattr__(self, "tariff_per_kwh", tariff)
         object.__setattr__(self, "source_ids", tuple(_text(s, "source_id") for s in sources))
         object.__setattr__(self, "segments", tuple(self.segments))

--- a/datacenter_twin/demo.py
+++ b/datacenter_twin/demo.py
@@ -1,5 +1,6 @@
 """Bundled synthetic scenario presets; no vendor or facility parameters inferred."""
 
+from decimal import Decimal
 from importlib.resources import files
 import json
 
@@ -12,28 +13,71 @@ PRESETS = {
     "generator_failure": "Generator failure / battery depletion",
     "path_maintenance": "A-path maintenance / surviving overload",
     "shared_domain": "Shared control-domain failure",
+    "ai_cluster_utility_loss": "50 MW AI cluster / generator pickup",
+    "ai_cluster_generator_failure": "50 MW AI cluster / generator failure",
 }
+
+_AI_CLUSTER_SOURCE_ID = "SYN-AI-50MW-001"
+_AI_CLUSTER_SCALE = Decimal("50")
+_AI_CLUSTER_EVENT_PRESETS = {
+    "ai_cluster_utility_loss": "utility_loss",
+    "ai_cluster_generator_failure": "generator_failure",
+}
+
+
+def _scenario_event(at_s: int, action: str, target: str) -> dict:
+    """Create an availability event with the contract's explicit null value."""
+    return {"at_s": at_s, "action": action, "target": target, "value_kw": None}
+
+
+def _events_for_preset(preset: str) -> list[dict]:
+    """Return the original outage sequence for a base or scaled preset."""
+    event_preset = _AI_CLUSTER_EVENT_PRESETS.get(preset, preset)
+    events = []
+    if event_preset in ("utility_loss", "generator_failure"):
+        events.append(_scenario_event(300, "asset_down", "utility"))
+        if event_preset == "generator_failure":
+            events.append(_scenario_event(300, "asset_down", "generator"))
+        events.append(_scenario_event(900, "asset_up", "utility"))
+        if event_preset == "generator_failure":
+            events.append(_scenario_event(900, "asset_up", "generator"))
+    elif event_preset == "path_maintenance":
+        events.append(_scenario_event(300, "asset_down", "path-a"))
+        events.append(_scenario_event(900, "asset_up", "path-a"))
+    elif event_preset == "shared_domain":
+        events.append(_scenario_event(300, "domain_down", "shared-controls"))
+        events.append(_scenario_event(900, "domain_up", "shared-controls"))
+    return events
+
+
+def _scale_ai_cluster(data: dict) -> None:
+    """Scale aggregate electrical quantities while retaining all timing inputs.
+
+    The result is a 50 MW electrical teaching case.  It carries no GPU count,
+    workload throughput, grid-adequacy, or facility-prediction claim.
+    """
+    for field in (
+        "it_demand_kw",
+        "it_capacity_kw",
+        "battery_capacity_kwh",
+        "battery_initial_kwh",
+        "battery_charge_kw",
+    ):
+        data[field] = str(Decimal(data[field]) * _AI_CLUSTER_SCALE)
+    for asset in data["assets"]:
+        asset["capacity_kw"] = str(
+            Decimal(asset["capacity_kw"]) * _AI_CLUSTER_SCALE
+        )
+    data["source_ids"] = [*data["source_ids"], _AI_CLUSTER_SOURCE_ID]
 
 
 def demo_scenario(preset: str = "utility_loss") -> SiteScenario:
     if preset not in PRESETS:
         raise InputError("Unknown demo preset")
-    data = json.loads(files("datacenter_twin").joinpath("resources/reference-site-v2.json").read_text(encoding="utf-8"))
-    events = []
-
-    def event(at, action, target):
-        events.append({"at_s": at, "action": action, "target": target, "value_kw": None})
-
-    if preset in ("utility_loss", "generator_failure"):
-        event(300, "asset_down", "utility")
-        if preset == "generator_failure": event(300, "asset_down", "generator")
-        event(900, "asset_up", "utility")
-        if preset == "generator_failure": event(900, "asset_up", "generator")
-    if preset == "path_maintenance":
-        event(300, "asset_down", "path-a")
-        event(900, "asset_up", "path-a")
-    if preset == "shared_domain":
-        event(300, "domain_down", "shared-controls")
-        event(900, "domain_up", "shared-controls")
-    data.update(id=f"demo-{preset}", name=PRESETS[preset], events=events)
+    resource = files("datacenter_twin").joinpath("resources/reference-site-v2.json")
+    data = json.loads(resource.read_text(encoding="utf-8"))
+    if preset in _AI_CLUSTER_EVENT_PRESETS:
+        _scale_ai_cluster(data)
+    data["events"] = _events_for_preset(preset)
+    data.update(id=f"demo-{preset}", name=PRESETS[preset])
     return SiteScenario.from_dict(data)

--- a/datacenter_twin/engine.py
+++ b/datacenter_twin/engine.py
@@ -14,7 +14,9 @@ ARITHMETIC = Context(prec=100, rounding=ROUND_HALF_EVEN)
 
 def simulate(scenario: Scenario) -> dict:
     if not isinstance(scenario, Scenario):
-        raise InputError("Expected a validated Scenario; use Scenario.from_dict for JSON objects")
+        raise InputError(
+            "Expected a validated Scenario; use Scenario.from_dict for JSON objects"
+        )
     canonical = json.dumps(scenario.to_dict(), sort_keys=True, separators=(",", ":"))
     input_hash = hashlib.sha256(canonical.encode()).hexdigest()
     run_id = hashlib.sha256(f"{__version__}:{input_hash}".encode()).hexdigest()[:20]
@@ -26,31 +28,58 @@ def simulate(scenario: Scenario) -> dict:
             it_kwh = segment.it_load_kw * segment.hours
             facility_kw = segment.it_load_kw * segment.assumed_pue
             facility_kwh = facility_kw * segment.hours
-            intervals.append({**segment.to_dict(), "facility_demand_kw": decimal_text(facility_kw),
-                              "it_energy_kwh": decimal_text(it_kwh),
-                              "facility_energy_kwh": decimal_text(facility_kwh),
-                              "exceeds_it_capacity": segment.it_load_kw > scenario.it_capacity_kw})
+            intervals.append(
+                {
+                    **segment.to_dict(),
+                    "facility_demand_kw": decimal_text(facility_kw),
+                    "it_energy_kwh": decimal_text(it_kwh),
+                    "facility_energy_kwh": decimal_text(facility_kwh),
+                    "exceeds_it_capacity": segment.it_load_kw > scenario.it_capacity_kw,
+                }
+            )
             total_hours += segment.hours
             it_energy += it_kwh
             facility_energy += facility_kwh
             peak_it = max(peak_it, segment.it_load_kw)
-        cost = (None if scenario.tariff_per_kwh is None else
-                format((facility_energy * scenario.tariff_per_kwh).quantize(Decimal("0.01")), ".2f"))
+        cost = (
+            None
+            if scenario.tariff_per_kwh is None
+            else format(
+                (facility_energy * scenario.tariff_per_kwh).quantize(Decimal("0.01")),
+                ".2f",
+            )
+        )
         return {
-            "schema_version": 1, "engine_version": __version__, "run_id": run_id,
-            "input_sha256": input_hash, "scenario_id": scenario.id, "scenario_name": scenario.name,
-            "mode": "SYNTHETIC_PLANNING", "fidelity": "coarse_assumed_pue",
-            "evidence_level": "arithmetic_verified_only", "source_ids": list(scenario.source_ids),
-            "assumptions": scenario.to_dict(), "currency": scenario.currency,
-            "boundary": "IT demand plus aggregate non-IT overhead; all facility energy assumed grid-imported",
-            "duration_hours": decimal_text(total_hours), "it_energy_kwh": decimal_text(it_energy),
+            "schema_version": 1,
+            "engine_version": __version__,
+            "run_id": run_id,
+            "input_sha256": input_hash,
+            "scenario_id": scenario.id,
+            "scenario_name": scenario.name,
+            "mode": "SYNTHETIC_PLANNING",
+            "fidelity": "coarse_assumed_pue",
+            "evidence_level": "arithmetic_verified_only",
+            "source_ids": list(scenario.source_ids),
+            "assumptions": scenario.to_dict(),
+            "currency": scenario.currency,
+            "boundary": (
+                "IT demand plus aggregate non-IT overhead; all facility energy assumed grid-imported"
+            ),
+            "duration_hours": decimal_text(total_hours),
+            "it_energy_kwh": decimal_text(it_energy),
             "facility_energy_kwh": decimal_text(facility_energy),
             "non_it_energy_kwh": decimal_text(facility_energy - it_energy),
-            "period_pue": None if it_energy == 0 else decimal_text(facility_energy / it_energy),
+            "period_pue": None
+            if it_energy == 0
+            else decimal_text(facility_energy / it_energy),
             "pue_undefined_reason": "No IT energy in this period" if it_energy == 0 else None,
             "peak_it_demand_kw": decimal_text(peak_it),
             "it_capacity_margin_kw": decimal_text(scenario.it_capacity_kw - peak_it),
-            "capacity_screen": "exceeds_envelope" if peak_it > scenario.it_capacity_kw else "within_envelope",
+            "capacity_screen": (
+                "exceeds_envelope"
+                if peak_it > scenario.it_capacity_kw
+                else "within_envelope"
+            ),
             "energy_only_cost": cost,
             "cost_unknown_reason": "Tariff is unknown" if cost is None else None,
             "intervals": intervals,
@@ -66,17 +95,35 @@ def simulate(scenario: Scenario) -> dict:
 def compare(baseline: Scenario, alternative: Scenario) -> dict:
     with localcontext(ARITHMETIC):
         if baseline.currency != alternative.currency:
-            raise InputError("Comparison requires the same currency; no FX conversion is implemented")
+            raise InputError(
+                "Comparison requires the same currency; no FX conversion is implemented"
+            )
         left, right = simulate(baseline), simulate(alternative)
         # Comparisons preserve workload and time so lower demand is not sold as an efficiency saving.
         left_work = [(s.hours, s.it_load_kw) for s in baseline.segments]
         right_work = [(s.hours, s.it_load_kw) for s in alternative.segments]
         if left_work != right_work:
             raise InputError("Comparison requires identical interval durations and IT loads")
-        savings = (None if left["energy_only_cost"] is None or right["energy_only_cost"] is None
-                   else format(Decimal(left["energy_only_cost"]) - Decimal(right["energy_only_cost"]), ".2f"))
-        return {"baseline": left, "alternative": right, "currency": baseline.currency,
-                "facility_energy_saving_kwh": decimal_text(Decimal(left["facility_energy_kwh"]) -
-                                                           Decimal(right["facility_energy_kwh"])),
-                "energy_only_cost_saving": savings,
-                "comparison_boundary": "Identical IT load intervals; baseline minus alternative. No investment ranking."}
+        savings = (
+            None
+            if left["energy_only_cost"] is None
+            or right["energy_only_cost"] is None
+            else format(
+                Decimal(left["energy_only_cost"])
+                - Decimal(right["energy_only_cost"]),
+                ".2f",
+            )
+        )
+        return {
+            "baseline": left,
+            "alternative": right,
+            "currency": baseline.currency,
+            "facility_energy_saving_kwh": decimal_text(
+                Decimal(left["facility_energy_kwh"])
+                - Decimal(right["facility_energy_kwh"])
+            ),
+            "energy_only_cost_saving": savings,
+            "comparison_boundary": (
+                "Identical IT load intervals; baseline minus alternative. No investment ranking."
+            ),
+        }

--- a/datacenter_twin/output.py
+++ b/datacenter_twin/output.py
@@ -8,7 +8,13 @@ from typing import Iterable
 from .contracts import InputError
 
 
-def write_result(path: Path, content: str, *, protected_paths: Iterable[Path] = (), force: bool = False) -> None:
+def write_result(
+    path: Path,
+    content: str,
+    *,
+    protected_paths: Iterable[Path] = (),
+    force: bool = False,
+) -> None:
     path = Path(path)
     for protected in protected_paths:
         protected = Path(protected)
@@ -38,7 +44,9 @@ def write_result(path: Path, content: str, *, protected_paths: Iterable[Path] = 
                 # Same-filesystem link creation is atomic and fails if the destination exists.
                 os.link(temporary_path, path)
             except FileExistsError as exc:
-                raise InputError("Output already exists; choose another path or use --force to replace it") from exc
+                raise InputError(
+                    "Output already exists; choose another path or use --force to replace it"
+                ) from exc
     finally:
         if temporary_path is not None:
             temporary_path.unlink(missing_ok=True)

--- a/datacenter_twin/reporting.py
+++ b/datacenter_twin/reporting.py
@@ -61,10 +61,20 @@ def _single_summary(result: dict) -> dict:
     summary.setdefault("served_kwh", summary.get("served_it_kwh", "unknown"))
     summary.setdefault("unserved_kwh", summary.get("unserved_it_kwh", "unknown"))
     summary.setdefault("unserved_seconds", summary.get("unserved_duration_s", "unknown"))
-    summary.setdefault("first_battery_depletion_s", next(
-        (event.get("at_s") for event in result.get("events", []) if event.get("action") == "battery_depleted"), None))
-    summary.setdefault("cost_unknowns", [key for key in ("generator_energy_charge", "total_incremental_energy_charge")
-                                          if summary.get(key) is None])
+    first_depletion = next(
+        (
+            event.get("at_s")
+            for event in result.get("events", [])
+            if event.get("action") == "battery_depleted"
+        ),
+        None,
+    )
+    summary.setdefault("first_battery_depletion_s", first_depletion)
+    cost_keys = ("generator_energy_charge", "total_incremental_energy_charge")
+    summary.setdefault(
+        "cost_unknowns",
+        [key for key in cost_keys if summary.get(key) is None],
+    )
     return summary
 
 
@@ -104,7 +114,11 @@ def _sweep_rows(result: dict) -> tuple[list[tuple[str, ...]], list[str]]:
             summary.get("served_kwh", summary.get("served_it_kwh", "unknown")),
             summary.get("unserved_kwh", summary.get("unserved_it_kwh", "unknown")),
             summary.get("unserved_seconds", summary.get("unserved_duration_s", "unknown")),
-            "none" if summary.get("first_battery_depletion_s") is None else summary.get("first_battery_depletion_s"),
+            (
+                "none"
+                if summary.get("first_battery_depletion_s") is None
+                else summary.get("first_battery_depletion_s")
+            ),
             summary.get("service_status", "unknown"),
             ", ".join(summary.get("cost_unknowns", [])) or "none",
             entry.get("run_id", "unknown"),
@@ -114,7 +128,11 @@ def _sweep_rows(result: dict) -> tuple[list[tuple[str, ...]], list[str]]:
         if detail:
             warnings.update(_warnings(detail))
         else:
-            warnings.update({str(name): int(count) for name, count in summary.get("warning_counts", {}).items()})
+            warning_counts = {
+                str(name): int(count)
+                for name, count in summary.get("warning_counts", {}).items()
+            }
+            warnings.update(warning_counts)
     return rows, [f"{name}: {count} interval(s)" for name, count in sorted(warnings.items())]
 
 
@@ -142,26 +160,54 @@ def render_markdown(result: dict) -> str:
             "", "## Sensitivity outcomes", "",
         ])
         rows, warning_lines = _sweep_rows(result)
-        lines.extend(_markdown_table(("Value", "Requested (kWh)", "Served (kWh)", "Unserved (kWh)",
-                                      "Unserved (s)", "Battery depletion (s)", "Service", "Cost unknowns",
-                                      "Run ID", "Input SHA-256"), rows))
+        lines.extend(
+            _markdown_table(
+                (
+                    "Value",
+                    "Requested (kWh)",
+                    "Served (kWh)",
+                    "Unserved (kWh)",
+                    "Unserved (s)",
+                    "Battery depletion (s)",
+                    "Service",
+                    "Cost unknowns",
+                    "Run ID",
+                    "Input SHA-256",
+                ),
+                rows,
+            )
+        )
     else:
         lines.extend([f"Run ID: {_md(result.get('run_id', 'unknown'))}",
                       f"Input SHA-256: {_md(result.get('input_sha256', 'unknown'))}",
                       "", "## Outcome", ""])
         lines.extend(_markdown_table(("Measure", "Value", "Unit"), _summary_rows(_single_summary(result))))
         lines.extend(["", "## Event timeline", ""])
-        lines.extend(_markdown_table(("At (s)", "Action", "Target", "Origin", "Ready at (s)"), _event_rows(result))
-                      if _event_rows(result) else ["No events were emitted."])
+        event_rows = _event_rows(result)
+        lines.extend(
+            _markdown_table(
+                ("At (s)", "Action", "Target", "Origin", "Ready at (s)"),
+                event_rows,
+            )
+            if event_rows
+            else ["No events were emitted."]
+        )
         warning_counts = _warnings(result)
         warning_lines = [f"{name}: {count} interval(s)" for name, count in sorted(warning_counts.items())]
     lines.extend(["", "## Scenario assumptions", ""])
     lines.extend(_markdown_table(("Field", "Value", "Unit"), _scenario_rows(scenario)))
     lines.extend(["", "## Warning summary", ""])
-    lines.extend(_markdown_table(("Warning", "Count"), [tuple(item.rsplit(": ", 1)) for item in warning_lines])
-                  if warning_lines else ["No interval warnings were emitted."])
+    lines.extend(
+        _markdown_table(
+            ("Warning", "Count"),
+            [tuple(item.rsplit(": ", 1)) for item in warning_lines],
+        )
+        if warning_lines
+        else ["No interval warnings were emitted."]
+    )
     if is_sweep:
-        lines.extend(["", f"Full per-run results included: {_md(result.get('full_results_included', False))}"])
+        full_results = _md(result.get("full_results_included", False))
+        lines.extend(["", f"Full per-run results included: {full_results}"])
     lines.extend(["", "## Assumptions", ""])
     lines.extend(f"- {_md(item)}" for item in result.get("assumptions", []))
     lines.extend(["", "## Limitations", ""])
@@ -171,7 +217,15 @@ def render_markdown(result: dict) -> str:
 
 def _html_table(headers: tuple[str, ...], rows: list[tuple[Any, ...]]) -> str:
     head = "".join(f"<th>{escape(str(value), quote=True)}</th>" for value in headers)
-    body = "".join("<tr>" + "".join(f"<td>{escape(str(value), quote=True)}</td>" for value in row) + "</tr>" for row in rows)
+    body = "".join(
+        "<tr>"
+        + "".join(
+            f"<td>{escape(str(value), quote=True)}</td>"
+            for value in row
+        )
+        + "</tr>"
+        for row in rows
+    )
     return f"<table><thead><tr>{head}</tr></thead><tbody>{body}</tbody></table>"
 
 
@@ -182,26 +236,99 @@ def render_html(result: dict) -> str:
     is_sweep = "runs" in result and "parameter" in result
     scenario = _scenario(result)
     title = "Datacenter Twin Lab continuity report"
-    parts = ["<!doctype html>", '<html lang="en">', "<head><meta charset=\"utf-8\"><title>"
-             + escape(title, quote=True) + "</title><style>body{font-family:system-ui,sans-serif;max-width:1100px;margin:2rem auto;padding:0 1rem}table{border-collapse:collapse;margin:1rem 0;width:100%}th,td{border:1px solid #ccc;padding:.35rem;text-align:left}th{background:#f2f2f2}code{word-break:break-all}</style></head><body>",
-             f"<h1>{escape(title)}</h1>",
-             f"<p>Model: <code>{escape(str(result.get('model', 'unknown')), quote=True)}</code><br>Engine version: <code>{escape(str(result.get('engine_version', 'unknown')), quote=True)}</code></p>"]
+    style = (
+        "<head><meta charset=\"utf-8\"><title>"
+        + escape(title, quote=True)
+        + "</title><style>"
+        "body{font-family:system-ui,sans-serif;max-width:1100px;margin:2rem auto;"
+        "padding:0 1rem}table{border-collapse:collapse;margin:1rem 0;width:100%}"
+        "th,td{border:1px solid #ccc;padding:.35rem;text-align:left}"
+        "th{background:#f2f2f2}code{word-break:break-all}"
+        "</style></head><body>"
+    )
+    model_details = (
+        f"<p>Model: <code>{escape(str(result.get('model', 'unknown')), quote=True)}"
+        f"</code><br>Engine version: <code>"
+        f"{escape(str(result.get('engine_version', 'unknown')), quote=True)}</code></p>"
+    )
+    parts = [
+        "<!doctype html>",
+        '<html lang="en">',
+        style,
+        f"<h1>{escape(title)}</h1>",
+        model_details,
+    ]
     if is_sweep:
-        parts.append(f"<p>Base input SHA-256: <code>{escape(str(result.get('base_input_sha256', 'unknown')), quote=True)}</code><br>Parameter: <code>{escape(str(result.get('parameter', 'unknown')), quote=True)}</code> ({escape(str(result.get('parameter_unit', '')), quote=True)})</p>")
+        base_details = (
+            f"<p>Base input SHA-256: <code>"
+            f"{escape(str(result.get('base_input_sha256', 'unknown')), quote=True)}</code>"
+            f"<br>Parameter: <code>"
+            f"{escape(str(result.get('parameter', 'unknown')), quote=True)}</code> ("
+            f"{escape(str(result.get('parameter_unit', '')), quote=True)})</p>"
+        )
+        parts.append(base_details)
         rows, warning_lines = _sweep_rows(result)
-        parts.extend(["<h2>Sensitivity outcomes</h2>", _html_table(("Value", "Requested (kWh)", "Served (kWh)", "Unserved (kWh)", "Unserved (s)", "Battery depletion (s)", "Service", "Cost unknowns", "Run ID", "Input SHA-256"), rows)])
+        sweep_headers = (
+            "Value",
+            "Requested (kWh)",
+            "Served (kWh)",
+            "Unserved (kWh)",
+            "Unserved (s)",
+            "Battery depletion (s)",
+            "Service",
+            "Cost unknowns",
+            "Run ID",
+            "Input SHA-256",
+        )
+        parts.extend(["<h2>Sensitivity outcomes</h2>", _html_table(sweep_headers, rows)])
     else:
-        parts.append(f"<p>Run ID: <code>{escape(str(result.get('run_id', 'unknown')), quote=True)}</code><br>Input SHA-256: <code>{escape(str(result.get('input_sha256', 'unknown')), quote=True)}</code></p>")
+        run_details = (
+            f"<p>Run ID: <code>{escape(str(result.get('run_id', 'unknown')), quote=True)}"
+            f"</code><br>Input SHA-256: <code>"
+            f"{escape(str(result.get('input_sha256', 'unknown')), quote=True)}</code></p>"
+        )
+        parts.append(run_details)
         warning_counts = _warnings(result)
         warning_lines = [f"{name}: {count} interval(s)" for name, count in sorted(warning_counts.items())]
-        parts.extend(["<h2>Outcome</h2>", _html_table(("Measure", "Value", "Unit"), _summary_rows(_single_summary(result))), "<h2>Event timeline</h2>"])
+        outcome_rows = _summary_rows(_single_summary(result))
+        parts.extend(
+            [
+                "<h2>Outcome</h2>",
+                _html_table(("Measure", "Value", "Unit"), outcome_rows),
+                "<h2>Event timeline</h2>",
+            ]
+        )
         event_rows = _event_rows(result)
-        parts.append(_html_table(("At (s)", "Action", "Target", "Origin", "Ready at (s)"), event_rows)
-                     if event_rows else "<p>No events were emitted.</p>")
-    parts.extend(["<h2>Scenario assumptions</h2>", _html_table(("Field", "Value", "Unit"), _scenario_rows(scenario)), "<h2>Warning summary</h2>"])
-    parts.append(_html_table(("Warning", "Count"), [tuple(item.rsplit(": ", 1)) for item in warning_lines]) if warning_lines else "<p>No interval warnings were emitted.</p>")
+        parts.append(
+            _html_table(
+                ("At (s)", "Action", "Target", "Origin", "Ready at (s)"),
+                event_rows,
+            )
+            if event_rows
+            else "<p>No events were emitted.</p>"
+        )
+    scenario_rows = _scenario_rows(scenario)
+    parts.extend(
+        [
+            "<h2>Scenario assumptions</h2>",
+            _html_table(("Field", "Value", "Unit"), scenario_rows),
+            "<h2>Warning summary</h2>",
+        ]
+    )
+    parts.append(
+        _html_table(
+            ("Warning", "Count"),
+            [tuple(item.rsplit(": ", 1)) for item in warning_lines],
+        )
+        if warning_lines
+        else "<p>No interval warnings were emitted.</p>"
+    )
     if is_sweep:
-        parts.append(f"<p>Full per-run results included: {escape(str(result.get('full_results_included', False)), quote=True)}</p>")
+        full_results = escape(
+            str(result.get("full_results_included", False)),
+            quote=True,
+        )
+        parts.append(f"<p>Full per-run results included: {full_results}</p>")
     for heading, key in (("Assumptions", "assumptions"), ("Limitations", "limitations")):
         items = "".join(f"<li>{escape(str(item), quote=True)}</li>" for item in result.get(key, []))
         parts.extend([f"<h2>{heading}</h2>", f"<ul>{items}</ul>"])

--- a/datacenter_twin/resources/catalog.json
+++ b/datacenter_twin/resources/catalog.json
@@ -3,6 +3,26 @@
   "reviewed_on": "2026-09-08",
   "sources": [
     {
+      "id": "SYN-AI-50MW-001",
+      "title": "Original 50 MW aggregate AI-cluster electrical scenarios",
+      "url": null,
+      "locator": "docs/scenarios/ai-cluster-50mw.md",
+      "retrieved_on": "2026-09-12",
+      "evidence_type": "synthetic_assumption",
+      "claim": "The original 1 MW fixture is scaled by 50 in electrical demand, capacities and storage: 50 MW requested IT power, 5 MWh stored battery energy, 30-second generator delay and unchanged efficiencies/event times.",
+      "limitations": "An aggregate electrical load example, not measured GPU jobs, a server count, grid adequacy, equipment selection or a facility prediction."
+    },
+    {
+      "id": "EDU-POWER-001",
+      "title": "Power systems for datacenter engineers: twelve original exercises",
+      "url": null,
+      "locator": "docs/tutorials/power-systems-course.md",
+      "retrieved_on": "2026-09-12",
+      "evidence_type": "synthetic_assumption",
+      "claim": "One-variable teaching exercises in power, energy, losses, finite storage, generator timing, path capacity, common failures, recovery and separate assumed-PUE annual energy.",
+      "limitations": "Worked answers apply to the stated default and challenge inputs. Path capacity is only one N+1 condition. PUE does not model cooling or supply continuity. No independent external review is claimed."
+    },
+    {
       "id": "DEMO-ELECTRICAL-002", "title": "Synthetic electrical continuity reference", "url": null,
       "locator": "resources/reference-site-v2.json", "retrieved_on": "2026-09-08", "evidence_type": "synthetic_assumption",
       "claim": "Original 1 MW IT-demand fixture with two 700 kW gross distribution paths, shared control domain, a 100 kWh battery and a 30-second generator delay.",

--- a/datacenter_twin/sensitivity.py
+++ b/datacenter_twin/sensitivity.py
@@ -30,7 +30,9 @@ def _value(value: Any, parameter: str, index: int) -> tuple[Decimal, str]:
     parsed = number(value, f"values[{index}]")
     if parameter == "generator_start_delay_s":
         if parsed != parsed.to_integral_value():
-            raise InputError(f"values[{index}]: generator_start_delay_s must be an integer number of seconds")
+            raise InputError(
+                f"values[{index}]: generator_start_delay_s must be an integer number of seconds"
+            )
         parsed = parsed.to_integral_value()
     return parsed, decimal_text(parsed)
 
@@ -97,7 +99,10 @@ def sweep_continuity(scenario: SiteScenario, parameter: str, values: list[str | 
     full_size = 0
     include_full = True
     for parsed, label in parsed_values:
-        candidate = replace(scenario, **{parameter: int(parsed) if parameter == "generator_start_delay_s" else parsed})
+        candidate_value = (
+            int(parsed) if parameter == "generator_start_delay_s" else parsed
+        )
+        candidate = replace(scenario, **{parameter: candidate_value})
         run = simulate_continuity(candidate)
         run_result = run.to_dict()
         if include_full:
@@ -142,7 +147,13 @@ def sweep_continuity(scenario: SiteScenario, parameter: str, values: list[str | 
         ],
         "limitations": [
             "This is a deterministic sensitivity sweep, not calibration or a forecast.",
-            "Cooling, workload queues, switching transients, protection studies and physical controls are outside the model.",
-            "Costs remain illustrative or unknown according to the scenario tariff and generator cost inputs.",
+            (
+                "Cooling, workload queues, switching transients, protection studies "
+                "and physical controls are outside the model."
+            ),
+            (
+                "Costs remain illustrative or unknown according to the scenario tariff "
+                "and generator cost inputs."
+            ),
         ],
     }

--- a/datacenter_twin/topology.py
+++ b/datacenter_twin/topology.py
@@ -106,7 +106,11 @@ class Event:
                 "value_kw": None if self.value_kw is None else decimal_text(self.value_kw)}
 
 
-def topological_order(assets: tuple[Asset, ...], dependencies: tuple[Dependency, ...], relation: str) -> list[str]:
+def topological_order(
+    assets: tuple[Asset, ...],
+    dependencies: tuple[Dependency, ...],
+    relation: str,
+) -> list[str]:
     ids = {asset.id for asset in assets}
     incoming = {asset_id: 0 for asset_id in ids}
     outgoing = {asset_id: [] for asset_id in ids}
@@ -174,9 +178,17 @@ class SiteScenario:
         if self.battery_initial_kwh > self.battery_capacity_kwh:
             raise InputError("battery_initial_kwh exceeds stored-energy capacity")
         object.__setattr__(self, "source_ids", string_list(self.source_ids, "source_ids"))
-        for field, kind, maximum in (("assets", Asset, 64), ("dependencies", Dependency, 256), ("events", Event, 128)):
+        for field, kind, maximum in (
+            ("assets", Asset, 64),
+            ("dependencies", Dependency, 256),
+            ("events", Event, 128),
+        ):
             values = getattr(self, field)
-            if not isinstance(values, (tuple, list)) or len(values) > maximum or any(not isinstance(v, kind) for v in values):
+            if (
+                not isinstance(values, (tuple, list))
+                or len(values) > maximum
+                or any(not isinstance(v, kind) for v in values)
+            ):
                 raise InputError(f"{field}: expected at most {maximum} {kind.__name__} records")
             object.__setattr__(self, field, tuple(values))
         by_id = {asset.id: asset for asset in self.assets}
@@ -198,9 +210,15 @@ class SiteScenario:
                 raise InputError("Duplicate dependency")
             seen.add(key)
             if edge.relation == "feeds":
-                if by_id[edge.target].kind in ("utility", "generator", "battery") or by_id[edge.source].kind == "load":
+                if (
+                    by_id[edge.target].kind in ("utility", "generator", "battery")
+                    or by_id[edge.source].kind == "load"
+                ):
                     raise InputError("Feeds must lead from sources toward the load")
-            if edge.relation == "charges" and (by_id[edge.target].kind != "battery" or by_id[edge.source].kind != "bus"):
+            if edge.relation == "charges" and (
+                by_id[edge.target].kind != "battery"
+                or by_id[edge.source].kind != "bus"
+            ):
                 raise InputError("Charging connections must lead from a bus to the battery")
         if sum(edge.relation == "charges" for edge in self.dependencies) != 1:
             raise InputError("Provide exactly one explicit bus-to-battery charging connection")
@@ -209,11 +227,20 @@ class SiteScenario:
         # Disconnected source paths are configuration errors; outage disconnections are simulated events.
         load = next(asset.id for asset in self.assets if asset.kind == "load")
         charging_bus = next(edge.source for edge in self.dependencies if edge.relation == "charges")
-        for source in (asset.id for asset in self.assets if asset.kind in ("utility", "generator", "battery")):
+        source_ids = (
+            asset.id
+            for asset in self.assets
+            if asset.kind in ("utility", "generator", "battery")
+        )
+        for source in source_ids:
             reachable = {source}
             for item in topological_order(self.assets, self.dependencies, "feeds"):
                 if item in reachable:
-                    reachable.update(edge.target for edge in self.dependencies if edge.source == item and edge.relation == "feeds")
+                    reachable.update(
+                        edge.target
+                        for edge in self.dependencies
+                        if edge.source == item and edge.relation == "feeds"
+                    )
             if load not in reachable:
                 raise InputError(f"Source {source} has no feed path to the load")
             if by_id[source].kind == "utility" and charging_bus not in reachable:
@@ -232,9 +259,16 @@ class SiteScenario:
         fields = set(cls.__dataclass_fields__)
         _keys(data, fields | {"schema_version"}, "continuity scenario")
         if type(data["schema_version"]) is not int or data["schema_version"] != 2:
-            raise InputError("Electrical continuity requires schema_version 2; v1 PUE scenarios cannot infer topology")
+            raise InputError(
+                "Electrical continuity requires schema_version 2; "
+                "v1 PUE scenarios cannot infer topology"
+            )
         values = {key: value for key, value in data.items() if key != "schema_version"}
-        for field, kind, maximum in (("assets", Asset, 64), ("dependencies", Dependency, 256), ("events", Event, 128)):
+        for field, kind, maximum in (
+            ("assets", Asset, 64),
+            ("dependencies", Dependency, 256),
+            ("events", Event, 128),
+        ):
             if not isinstance(values[field], list) or len(values[field]) > maximum:
                 raise InputError(f"{field}: expected a bounded JSON array")
             values[field] = tuple(kind.from_dict(item) for item in values[field])

--- a/docs/choosing-a-simulator.md
+++ b/docs/choosing-a-simulator.md
@@ -1,0 +1,31 @@
+# Choosing a simulator for the question
+
+The right tool depends on the question you need to answer and the inputs you can defend.
+
+| If your task is… | Start with… | Inputs or question to prepare |
+| --- | --- | --- |
+| Learn event timing and energy accounting for a synthetic continuity case | [Datacenter Twin Lab](../README.md) | Aggregate IT demand in kW, stored battery energy in kWh, source/path capacities, efficiencies, and event boundaries. Ask how much load is served, when storage depletes, or how a path limit changes unserved energy. |
+| Explore cloud datacenter behavior and performance scenarios | [OpenDC](https://opendc.org/) | Define the datacenter scenario and the performance question. OpenDC's official site describes online cloud datacenter modeling, exploratory simulation, and scenarios involving cloud, serverless, big data, and machine learning. |
+| Simulate or optimize a broader power and energy system | [PyPSA](https://docs.pypsa.org/latest/) | Define network components, time series, constraints, objective, and planning horizon. PyPSA's official documentation describes simulation and optimization with generators, unit commitment, storage, sector coupling, and linearized power flow, aimed at researchers, planners, and utilities. |
+
+## When Datacenter Twin Lab fits
+
+Choose Datacenter Twin Lab when the immediate learning question is about continuity at an IT boundary: a finite reserve, a generator delay or failure, a surviving distribution path, a shared failure domain, or the energy ledger around explicit events. The browser lessons and the Python reference route expose the units and hand calculations so a reader can follow the result before changing assumptions.
+
+Use the [scenario catalog](scenarios/index.md) for the current cases and the [continuity walkthrough](tutorials/continuity-walkthrough.md) for the 665 kW surviving-path and 307.8 s battery examples.
+
+## When OpenDC fits
+
+Choose OpenDC when you need to explore datacenter performance questions in the domain described by its official site, such as cloud, serverless, big-data, or machine-learning scenarios. Its online interface, exploratory simulation, and generated visual summaries are useful starting points for that task. Read the [OpenDC site](https://opendc.org/) for its current models, tutorials, and documentation.
+
+## When PyPSA fits
+
+Choose PyPSA when the question requires a power or energy-system network, time series, optimization constraints, storage operation, unit commitment, sector coupling, or linearized power-flow analysis. The [PyPSA documentation](https://docs.pypsa.org/latest/) lists these areas and provides user guides, examples, and API reference material for researchers, planners, and utilities.
+
+## Shared assumptions and limits
+
+These tools answer different questions through different model boundaries. Datacenter Twin Lab's public fixtures are deterministic, synthetic, and centered on one aggregate IT load with explicit continuity events, finite storage, conversion losses, path limits, and exact energy accounting. They do not establish GPU job throughput, grid adequacy, equipment suitability, cooling behavior, facility calibration, certification, or physical safety. A 50 MW AI-cluster case in this repository is a scaled teaching input, not a site model.
+
+OpenDC and PyPSA should be assessed from their current official documentation and the specific model you construct. This page does not claim a feature-by-feature equivalence, a head-to-head benchmark, measured speed, or that one tool replaces another. For any tool, state the data source, units, time resolution, objective, assumptions, validation evidence, and decision boundary before treating an output as engineering evidence.
+
+Official pages checked **2026-09-12**: [OpenDC](https://opendc.org/) and [PyPSA documentation](https://docs.pypsa.org/latest/).

--- a/docs/engineering/browser-demo.md
+++ b/docs/engineering/browser-demo.md
@@ -1,20 +1,28 @@
 # Browser demo
 
-The [zero-install demo](https://mohammadrezwankhan.github.io/datacenter-twin-lab/) runs the original Python continuity engine in a Web Worker through pinned Pyodide 314.0.6 (CPython 3.14.2). It serves static files through GitHub Pages; there is no shared simulation API. The Python source archive has an explicit per-file manifest and a checked SHA-256 digest. Browser and native tests compare entire results for all five presets, including run IDs, exact energy ledgers, and event times.
+Open the [50 MW outage experiment](https://mohammadrezwankhan.github.io/datacenter-twin-lab/) and change the reserve, or follow [twelve browser lessons](../tutorials/power-systems-course.md). The first result uses the local JavaScript continuity engine. **Verify against Python** explicitly loads the reference Python engine when you want a second calculation.
+
+The JavaScript port uses exact rational arithmetic for dispatch and accounting, then matches Python's 100-digit decimal formatting, canonical inputs and result hashes. It handles the bounded topology contract, including max-flow, charging, generator delay, shared failures and event boundaries. It does not use a preset lookup table of precomputed results. Reports, sensitivity and the separate PUE exercise also calculate locally.
+
+Both engines run in Web Workers. The optional Python check uses pinned Pyodide 314.0.6 (CPython 3.14.2). The Python source archive has an explicit per-file manifest and a checked SHA-256 digest. Equality checks compare the complete result: normalized inputs, hashes, interval ledger, warnings and event times. A mismatch is an error; it cannot produce a successful verification badge. A failed optional download leaves the completed JavaScript result available and offers retry.
 
 The browser compares the downloaded archive with its manifest's archive digest. Per-file hashes are audit metadata, not separate browser checks; they describe archived text after CRLF-to-LF normalization. Compare normalized source bytes when auditing on Windows. These hashes detect mismatched files and do not replace trust in the host serving both archive and manifest.
 
 ## First experiment
 
-The opening generator-failure case loses utility and generator availability at 300 s and restores utility at 900 s. With 100 kWh initial battery energy, depletion occurs at 607.8 s. Change **Initial battery** to **50 kWh** and run again. Depletion moves to **478.2675 s**, displayed as 478.3 s: the battery charges during the first 300 s while utility is available. Its outage-opening balance is `50 + 100 × 0.95 × 300/3600 = 57.916666... kWh`; ride-through is that balance times `0.90 × 0.95 × 3600/1000 = 178.2675 s`.
+The opening generator-failure case loses utility and generator availability at 300 s and restores utility at 900 s. With 5,000 kWh initial battery energy in the 50 MW case, depletion occurs at 607.8 s. Change **Initial battery** to **2,500 kWh** and run again. Depletion moves to **478.2675 s**, displayed as 478.3 s: the battery charges during the first 300 s while utility is available. Its outage-opening balance is `2500 + 5000 × 0.95 × 300/3600 = 2895.833333... kWh`; ride-through is that balance times `0.90 × 0.95 × 3600/50000`, giving `178.2675 s`.
 
 Use the event buttons to inspect failure and recovery, export JSON, download a Markdown/HTML report, or compare empty/half/full initial reserves. Reports use the last completed scenario; unapplied edits are labeled. For a simpler hand calculation with charging disabled, use the [reproducibility capsule](../validation/reproducibility-capsule.md).
 
+## Observed first result
+
+The [12 September local observation](../validation/browser-entry-measurement.json) recorded **322,816 decoded response bytes** for the first 50 MW result, including a **42,262-byte JavaScript worker**, and **605 ms** from navigation to the displayed result. This was one fresh Chromium context against loopback Vite on Windows, with no network or CPU throttling. It is not a compressed transfer size or a promise of visitor latency. The test confirms no Pyodide, Python archive, catalog or cover request on this path.
+
 ## Privacy and limits
 
-The first visit downloads about 14 MB of runtime and application assets; browser cache can reduce later transfers. All runtime assets come from the same site. The application sends no scenario inputs, exports, completion events, cookies, or analytics identifiers to a server. Host request logs are governed by [GitHub's privacy statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement). Browser extensions and local filtering software may make their own requests; they are outside the application.
+The first result does not request Pyodide, the Python source archive or the cover image. The optional verifier downloads about 14 MB the first time; browser cache can reduce later transfers. The browser test writes a timestamped `first-result-measurement.json` listing observed decoded response sizes and local time to result. Its 600,000-byte regression budget covers the default journey; local timing is not a claim about every visitor or network. All runtime assets come from the same site. The application sends no scenario inputs, exports, completion events, cookies, or analytics identifiers to a server. Host request logs are governed by [GitHub's privacy statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement). Browser extensions and local filtering software may make their own requests; they are outside the application.
 
-There is no automatic collection of demo completion or repeat use. Those metrics remain unknown unless someone voluntarily reports a reproducible journey. Browser execution uses the same validated scenario contract (including a 4 MiB request limit and bounded simulation size), plus a 90-second worker deadline. A deadline terminates the worker and reports an actionable error. Closing/reloading the page discards workspace state. Downloads happen only when requested. There is no service worker or offline-install guarantee.
+There is no automatic collection of demo completion or repeat use. Those metrics remain unknown unless someone voluntarily reports a reproducible journey. Browser execution uses the same bounded scenario contract (including a 4 MiB request limit and bounded simulation size), plus a 90-second worker deadline. A deadline terminates the worker and reports an actionable error. Closing/reloading the page discards workspace state. Downloads happen only when requested. There is no service worker or offline-install guarantee.
 
 Results remain synthetic and uncalibrated. This does not establish facility safety, cooling or workload performance, AC transients, protection coordination, certified uptime, or live controls. No login or sensitive inputs are required.
 
@@ -25,6 +33,7 @@ Use Python 3.12+ and Node 24 from the repository root:
 ```sh
 npm --prefix apps/web ci --ignore-scripts
 python scripts/prepare_browser_demo.py
+npm --prefix apps/web run test:engine
 npm --prefix apps/web run build:demo
 npm --prefix apps/web exec playwright install chromium
 npm --prefix apps/web run test:demo
@@ -32,6 +41,6 @@ npm --prefix apps/web run test:demo
 
 If Python is not on PATH, set `TWIN_PYTHON` to its executable before the browser tests. The build lives in `.local/browser-demo-site` and uses the `/datacenter-twin-lab/` base path. From `apps/web`, run `npx vite preview --mode demo --host 127.0.0.1 --port 4174` and open `http://127.0.0.1:4174/datacenter-twin-lab/`. Stop that preview before running `test:demo`, which starts its own server on the same port.
 
-The HTML entry includes a readable example and Python/documentation links before scripts load. If JavaScript is disabled, it explicitly directs visitors to those alternatives; it does not claim the interactive simulation works without JavaScript. Phone-width and JavaScript-disabled journeys are checked alongside browser/native equality. The [recorded walkthrough](../examples/demo-walkthrough.md) provides a small visual preview and a text transcript.
+The HTML entry includes a readable example and Python/documentation links before scripts load. If JavaScript is disabled, it explicitly directs visitors to those alternatives; it does not claim the interactive simulation works without JavaScript. Seven presets and all twelve default/challenge lesson pairs are checked against native Python. Phone-width and JavaScript-disabled journeys, optional Python verification, corruption/retry and default network requests are checked as well. The [recorded walkthrough](../examples/demo-walkthrough.md) provides a small visual preview and a text transcript.
 
-`npm run build` in `apps/web` still produces the small loopback dashboard for the Python wheel. It does not include the browser Python runtime. See [third-party notices](../third-party/README.md) and the pinned dependency lockfile. The static deployment workflow requires native tests, browser/native equality, and browser journeys before uploading an artifact.
+`npm run build` in `apps/web` still produces the small loopback dashboard for the Python wheel. It does not include the browser Python runtime. See [third-party notices](../third-party/README.md) and the pinned dependency lockfile. The static deployment workflow requires native tests, JavaScript/native differential checks and browser journeys before uploading an artifact. These are maintainer software checks, not an independent external technical review.

--- a/docs/examples/demo-walkthrough.md
+++ b/docs/examples/demo-walkthrough.md
@@ -1,10 +1,10 @@
-# Watch and reproduce the first experiment
+# Watch and reproduce the 1 MW experiment
 
-[Open the interactive demo](https://mohammadrezwankhan.github.io/datacenter-twin-lab/) or [view a still frame](../images/demo-preview.png).
+[Open the current 1 MW experiment](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?preset=generator_failure) or [view a still frame](../images/demo-preview.png).
 
 ![Actual browser walkthrough](../images/demo-walkthrough.gif)
 
-This 21-second animation contains seven unannotated screenshots from the actual application, held for three seconds each. It omits waiting, downloads, and pointer movement. It does not measure load or calculation speed. The fixture is synthetic and uncalibrated.
+This preserved 0.3.0a0 interface recording predates the JavaScript entry and 50 MW course. Its 21-second animation contains seven unannotated screenshots from the actual application, held for three seconds each. It omits waiting, downloads, and pointer movement. It does not measure load or calculation speed. The fixture is synthetic and uncalibrated.
 
 | Frame | What happens |
 | --- | --- |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,8 +1,24 @@
 # Quickstart
 
-![Datacenter Twin Lab visual concept for the champion roadmap](images/datacenter-twin-lab-cover-v1.png)
+**Question:** how long can a finite battery support a large aggregate AI-cluster load after utility and generator power fail?
 
-For a zero-install first run, open the [browser demo](https://mohammadrezwankhan.github.io/datacenter-twin-lab/); it runs Python on your device and requires no account. See the [browser guide](engineering/browser-demo.md) for download size and privacy. For a local installation, choose the released dashboard to explore the model with Python and a browser, or use the source checkout to edit code and run the full tests. Both routes require Python 3.12 or later. The CLI and electrical engine use only the standard library; the dashboard server needs the optional API dependencies.
+The browser teaching case uses a synthetic **50,000 kW (50 MW)** IT request and **5,000 kWh (5 MWh)** initial battery energy. With the modeled 0.90 discharge and 0.95 distribution efficiencies, it supplies IT for **307.8 s** and records battery depletion at **607.8 s elapsed**. This is the first useful result; installation options follow it.
+
+## Run the browser case first
+
+1. Open the [zero-install browser demo](https://mohammadrezwankhan.github.io/datacenter-twin-lab/).
+2. Run **AI-cluster generator failure** with the default values.
+3. Select **Battery depleted 607.8 s** and inspect the interval with **0 kW served IT power** until utility restoration at **900 s**.
+
+The [12-lesson course starts with power and energy](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=power-energy). The topical AI-outage lesson is available at [`?lesson=ai-outage`](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=ai-outage) after the course route is present. Supporting [course notes](tutorials/power-systems-course.md) and the [AI-cluster scenario note](scenarios/ai-cluster-50mw.md) are supplied with the course update.
+
+The default browser journey uses exact JavaScript arithmetic locally. Select **Verify against Python** only when you want the optional Pyodide cross-check; it loads the Python runtime on demand rather than downloading it for the initial result. Runtime and measurement details are documented in the [browser guide](engineering/browser-demo.md).
+
+## Reproduce the original 1 MW reference case
+
+The original `generator_failure` preset remains available at [`?preset=generator_failure`](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?preset=generator_failure). It uses a synthetic **1,000 kW IT request** and **100 kWh battery**, so the same ratio gives 307.8 s of battery ride-through and depletion at 607.8 s. Change **Initial battery** from **100** to **50 kWh**, run the scenario, and inspect the battery-depleted event; pre-outage charging explains the **478.2675 s** result.
+
+For a recorded 1 MW walkthrough, use the optional [still image](images/demo-preview.png) and [transcript/capture recipe](examples/demo-walkthrough.md). The recording omits waiting and pointer movement and is not a speed benchmark. Refresh it if the current browser controls or labels differ.
 
 ## Run with uv
 
@@ -12,7 +28,7 @@ If [uv is installed](https://docs.astral.sh/uv/getting-started/installation/), r
 uvx --python 3.12 --from "datacenter-twin-lab @ https://github.com/mohammadrezwankhan/datacenter-twin-lab/releases/download/v0.3.0a0/datacenter_twin_lab-0.3.0a0-py3-none-any.whl#sha256=b951f6877fb323c8ff3a064558054383d4d1582e753e52c0a0c35b06a42739db" datacenter-twin simulate --preset generator_failure --format markdown
 ```
 
-For the local dashboard, use the same released wheel with its API extra:
+This command intentionally reproduces the original 1 MW / 100 kWh reference fixture. For the local dashboard, use the same released wheel with its API extra:
 
 ```sh
 uvx --python 3.12 --from "datacenter-twin-lab[api] @ https://github.com/mohammadrezwankhan/datacenter-twin-lab/releases/download/v0.3.0a0/datacenter_twin_lab-0.3.0a0-py3-none-any.whl#sha256=b951f6877fb323c8ff3a064558054383d4d1582e753e52c0a0c35b06a42739db" datacenter-twin serve
@@ -42,9 +58,9 @@ python3 -m venv .venv
 .venv/bin/python -m datacenter_twin serve
 ```
 
-Use a Python executable at version 3.12 or later; for example, replace the first Windows `python` with `py -3.12` if you use that launcher. Your Python installation must include pip and venv support. The initial installation needs network access to GitHub and the dependency package index. It installs the built interface and API dependencies; Git, Node, an API key and a cloud account are not required. The release pins FastAPI and Uvicorn; this convenient extra resolves their compatible transitive dependencies. Use the locked source workflow below when you need the repository's exact development dependency set.
+Use a Python executable at version 3.12 or later; for example, replace the first Windows `python` with `py -3.12` if you use that launcher. Your Python installation must include pip and venv support. The initial installation needs network access to GitHub and the dependency package index. It installs the built interface and API dependencies; Git, Node, an API key, and a cloud account are not required. The release pins FastAPI and Uvicorn; this convenient extra resolves their compatible transitive dependencies. Use the locked source workflow below when you need the repository's exact development dependency set.
 
-Open [127.0.0.1:8000](http://127.0.0.1:8000). Select **Generator failure / battery depletion**, run the scenario, and select the `607.8 s` battery-depleted event. Served IT power drops to zero until restoration at `900 s`. The source is synthetic and the tariff is fictional. Try **A-path maintenance / surviving overload** to see 665 kW served and 335 kW unserved during the outage interval. [The tutorial](tutorials/continuity-walkthrough.md) derives both results.
+Open [127.0.0.1:8000](http://127.0.0.1:8000). Select **Generator failure / battery depletion**, run the original 1 MW scenario, and select the `607.8 s` battery-depleted event. Served IT power drops to zero until restoration at `900 s`. Try **A-path maintenance / surviving overload** to see 665 kW served and 335 kW unserved during the outage interval. [The tutorial](tutorials/continuity-walkthrough.md) derives both results.
 
 Stop the server with Ctrl+C. If port 8000 is occupied, append `--port 8001` to the serve command and open port 8001. After stopping, you can run the bundled CLI preset in the same environment:
 
@@ -58,7 +74,7 @@ Stop the server with Ctrl+C. If port 8000 is occupied, append `--port 8001` to t
 .venv/bin/python -m datacenter_twin simulate --preset generator_failure
 ```
 
-The presets and catalogue ship in the wheel. Source-only files such as `data/scenarios/baseline-1mw.json` and the test suite require the checkout below. Avoid running the installed dashboard from inside an unbuilt source checkout, where Python can import that checkout instead of the installed package. The server binds to loopback; this is a local research tool with no physical controls or calibrated facility claims.
+The presets and catalogue ship in the wheel. Source-only files such as `data/scenarios/baseline-1mw.json` and the test suite require the checkout below. Avoid running the installed dashboard from inside an unbuilt source checkout, where Python can import that checkout instead of the installed package.
 
 ## Run from source
 
@@ -74,11 +90,11 @@ python -m unittest discover -s tests -v
 
 The same module commands work in PowerShell. If `python` opens the Microsoft Store, use the path to an installed Python executable or your Python launcher (`py -3.12`). The launcher alternative is environment-dependent; the module commands were tested using a concrete Python 3.12.14 executable.
 
-Inspect `outputs/comparison.json`: `facility_energy_saving_kwh` is `"876000"` and `energy_only_cost_saving` is `"87600.00"`. Power, energy, rates and cost outputs are decimal strings; unavailable quantities are null. Counts and input duration/step fields remain integers. The output includes the full assumptions, engine version, source IDs, input hashes and stable run IDs.
+Inspect `outputs/comparison.json`: `facility_energy_saving_kwh` is `"876000"` and `energy_only_cost_saving` is `"87600.00"`. Power, energy, rates, and cost outputs are decimal strings; unavailable quantities are null. Counts and input duration/step fields remain integers. The output includes the full assumptions, engine version, source IDs, input hashes, and stable run IDs.
 
-Edit a copy of a scenario. Each interval has a label, duration in hours, IT demand in kW and assumed PUE. The tariff is per facility kWh. Increase IT demand to see consistent changes to energy, cost and capacity margin. Use `null` tariff plus `"unknown"` price status to see an explicitly unknown cost.
+Edit a copy of a scenario. Each interval has a label, duration in hours, IT demand in kW, and assumed PUE. The tariff is per facility kWh. Increase IT demand to see consistent changes to energy, cost, and capacity margin. Use `null` tariff plus `"unknown"` price status to see an explicitly unknown cost.
 
-Comparisons require identical IT load intervals and currency. This prevents a shorter or smaller workload from being reported as an efficiency saving. Changes to capacity, PUE and tariff remain visible in each result's assumptions.
+Comparisons require identical IT load intervals and currency. This prevents a shorter or smaller workload from being reported as an efficiency saving. Changes to capacity, PUE, and tariff remain visible in each result's assumptions.
 
 `outputs/` is ignored by Git. Choose a new export path on each run, or add `--force` to replace an existing result. The CLI protects the input even when the output is a hard-link alias. Symbolic-link outputs are rejected. A failed write preserves the previous result. Normal atomic creation requires a filesystem supporting hard links, as tested on the Windows/Linux environments; unsupported filesystems return an error. The program returns exit code 2 with a useful message for invalid input, including files larger than 4 MiB.
 
@@ -96,7 +112,7 @@ python -m datacenter_twin serve
 
 Open [127.0.0.1:8000](http://127.0.0.1:8000). Stop with Ctrl+C. Use `--port 8001` if the default port is occupied. The CLI cannot bind externally. The minimal API-only install is `python -m pip install -e ".[api]"`; the lock file also includes HTTP test dependencies and pins transitive versions. The `test-api` extra is available for development.
 
-Select **Generator failure / battery depletion**, then select the battery-depleted event to see zero served IT power. Select utility restoration to see recovery and charging. Change IT demand and run again; unapplied controls do not silently alter existing results. **Save baseline** lasts for the browser session; **Export run** downloads the exact API result. The CLI uses a `result` envelope and export timestamp around that same run. No account, GPU or cloud resource is needed.
+Select **Generator failure / battery depletion**, then select the battery-depleted event to see zero served IT power. Select utility restoration to see recovery and charging. Change IT demand and run again; unapplied controls do not silently alter existing results. **Save baseline** lasts for the browser session; **Export run** downloads the exact API result. The CLI uses a `result` envelope and export timestamp around that same run. No account, GPU, or cloud resource is needed.
 
 For a custom graph, copy [reference-site-v2.json](../datacenter_twin/resources/reference-site-v2.json), edit it under the [schema-2 rules](contracts/electrical-v2.md), then run `python -m datacenter_twin simulate --scenario path/to/copy.json`. Schema-1 PUE inputs remain supported by `run` and `compare`; they cannot infer electrical topology.
 
@@ -121,6 +137,16 @@ python -m pip wheel . --no-deps --wheel-dir dist
 python scripts/verify_distribution.py dist --require-web
 ```
 
-The verifier expects exactly one project wheel in the selected directory. Use a separate directory for each retained version. The build retrieves the pinned setuptools backend if uncached. The verifier creates a temporary environment, installs the local wheel with `--no-index --no-deps`, checks import/version identity and exercises both entry points plus continuity and catalogue resources. Schema-1 samples are copied from this repository. The schema-2 demo and catalogue are package resources. `--require-web` also checks that the compiled dashboard is included; omit it for an intentional CLI-only wheel. The installed core needs no network; an installed dashboard server still requires the optional API dependencies.
+The verifier expects exactly one project wheel in the selected directory. Use a separate directory for each retained version. The verifier creates a temporary environment, installs the local wheel with `--no-index --no-deps`, checks import/version identity, and exercises both entry points plus continuity and catalogue resources. Schema-1 samples are copied from this repository. The schema-2 demo and catalogue are package resources. `--require-web` also checks that the compiled dashboard is included; omit it for an intentional CLI-only wheel. The installed core needs no network; an installed dashboard server still requires the optional API dependencies.
 
 CI runs the core and API tests, frontend type check/build, and installed-wheel verification on Windows/Ubuntu with Python 3.12/3.14. Browser journeys run on Ubuntu/Python 3.12. PyPI publication remains pending a configured owner publishing identity; the verified GitHub wheel supports both pip and uv today. Containers and shared deployment are outside this delivery.
+
+## Assumptions and limits
+
+The 50 MW browser case is a synthetic 50× scale-up of the verified 1 MW / 100 kWh fixture. It uses 50,000 kW demand, 5,000 kWh initial battery energy, 0.90 discharge efficiency, and 0.95 distribution efficiency. It does not model GPU throughput, grid adequacy, selected equipment, site calibration, cooling, workload queues, battery aging, temperature, generator ramp/cooldown/fuel dynamics, transfer and switching transients, AC load flow, impedance-based sharing, protection coordination, harmonics, short-circuit or arc-flash behavior, reliability probabilities, Tier claims, service-level claims, certification, physical controls, or physical safety.
+
+The 1 MW source fixture remains the reproducible CLI reference: 1,000 kW IT request, 1,800 s duration, 100 kWh initial and maximum battery energy, 30 s generator start delay, 700 kW path capacities, and a fictional USD 0.10/kWh tariff. These are synthetic assumptions, not live prices, account quotes, equipment ratings, a benchmark, a legal-compliance result, or a real-site calibration. Unknown costs and unavailable quantities remain explicit.
+
+The browser demo has no shared simulation backend or client analytics. The API binds to loopback. No shared deployment, database, login, tenant isolation, persistent audit, live telemetry, FAT/SAT, independent external review, formal security audit, or validation dataset is included. Reference-case timing measures one local machine and does not establish scale targets or physical accuracy.
+
+The public source tree excludes private manuals, planning references and the private repository history. Do not add private manuals, extracted private text, credentials, customer traces, or licensed standards text. Original code and synthetic fixtures use [Apache-2.0](../LICENSE); see [NOTICE](../NOTICE) and [browser runtime licenses](third-party/README.md).

--- a/docs/scenarios/ai-cluster-50mw.md
+++ b/docs/scenarios/ai-cluster-50mw.md
@@ -1,0 +1,95 @@
+# 50 MW aggregate AI-cluster continuity case
+
+**Question:** when a synthetic 50 MW aggregate IT load loses utility and generator supply, how long does a 5 MWh battery reserve support the IT boundary?
+
+The answer for this fixture is **307.8 s of battery ride-through**. The outage starts at **300 s**, so the battery-depleted event is at **607.8 s**. Utility and generator restoration is scheduled for **900 s**.
+
+## Run the case in the browser
+
+- [Open the default AI-cluster case](https://mohammadrezwankhan.github.io/datacenter-twin-lab/), which selects `ai_cluster_generator_failure`.
+- [Open the generator-failure preset directly](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?preset=ai_cluster_generator_failure).
+- [Try utility loss with generator pickup](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?preset=ai_cluster_utility_loss).
+- [Study the same scale in lesson 10](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=ai-outage), then [start the full course](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=power-energy).
+
+Run the case, select the **Battery depleted 607.8 s** event, and inspect the interval after depletion. Served IT power is zero until the utility restoration event at 900 s. The browser's default calculation uses exact JavaScript arithmetic; **Verify against Python** is an optional action after a run.
+
+## Inputs and scaled electrical quantities
+
+The preset starts from the repository's synthetic 1 MW reference graph and scales the aggregate electrical quantities by 50. The timing inputs and efficiency ratios stay unchanged.
+
+| Quantity | AI-cluster fixture | Unit | How to read it |
+| --- | ---: | --- | --- |
+| Requested IT demand | 50,000 | kW (50 MW) | Aggregate electrical demand at the IT boundary. |
+| IT capacity | 50,000 | kW | Declared capacity for the aggregate request. |
+| Initial and maximum stored battery energy | 5,000 | kWh (5 MWh) | Stored energy before discharge and distribution losses. |
+| Battery power capacity | 60,000 | kW | Scaled synthetic battery asset limit. |
+| Battery charge power | 5,000 | kW | Maximum modeled charging input before charge efficiency. |
+| Battery discharge efficiency | 0.90 | ratio | Fraction retained through modeled battery discharge. |
+| Distribution efficiency | 0.95 | ratio | Fraction of dispatched gross path power reaching the IT boundary. |
+| Utility capacity | 75,000 | kW | Scaled synthetic source capacity. |
+| Generator capacity | 60,000 | kW | Scaled synthetic source capacity. |
+| Each distribution path | 35,000 gross | kW | A single path can deliver at most 33,250 kW after 0.95 distribution efficiency. |
+| Generator start delay | 30 | s | Applies when the utility-loss case requests generator pickup. |
+| Utility loss / restoration | 300 / 900 | s elapsed | Explicit event boundaries shared by the two AI presets. |
+
+These are fixture inputs for a continuity lesson. They are not selected equipment, a facility design, a GPU-cluster specification, or a grid connection study.
+
+The preset retains the reference fixture's `DEMO-ELECTRICAL-002` provenance and adds the synthetic scale-case identifier `SYN-AI-50MW-001`. These identifiers describe the input records; they are not vendor or facility sources.
+
+## Independent calculation: generator failure
+
+The modeled battery and distribution losses combine multiplicatively:
+
+```text
+total modeled efficiency = 0.90 × 0.95 = 0.855
+IT-boundary reserve      = 5,000 kWh × 0.855 = 4,275 kWh
+ride-through             = 4,275 kWh / 50,000 kW × 3,600 s/h
+                         = 307.8 s
+battery depletion       = 300 s + 307.8 s = 607.8 s
+```
+
+After depletion, the load remains unserved until the 900 s restoration boundary:
+
+```text
+unserved duration       = 900 s − 607.8 s = 292.2 s
+unserved IT energy      = 50,000 kW × 292.2 s / 3,600 s/h
+                        = 4,058.333333... kWh
+```
+
+The same result can be checked by scaling the reference fixture: `100 kWh × 50 = 5,000 kWh`, `1,000 kW × 50 = 50,000 kW`, and the power/energy ratio remains unchanged. This is an arithmetic scale check, not a claim that a real 50 MW site behaves like the fixture.
+
+## Independent calculation: utility loss and generator pickup
+
+The `ai_cluster_utility_loss` preset removes utility supply at 300 s and restores it at 900 s. The generator is ready after its 30 s start delay, at **330 s**. The battery bridges that interval:
+
+```text
+IT energy bridged = 50,000 kW × 30 s / 3,600 s/h
+                  = 416.666666... kWh at the IT boundary
+```
+
+The fixture's source and path capacities allow that declared aggregate request in this case. Inspect the event log and energy ledger in the browser result to distinguish the 30 s bridge from the longer generator-failure outage.
+
+## Compare with the 1 MW reference
+
+The original Python CLI presets remain useful for an independently runnable calculation:
+
+```sh
+python -m datacenter_twin simulate --preset generator_failure --format markdown --output outputs/one-mw-generator-failure.md
+python -m datacenter_twin simulate --preset utility_loss --format markdown --output outputs/one-mw-utility-loss.md
+python -m datacenter_twin simulate --preset ai_cluster_generator_failure --format markdown --output outputs/ai-generator-failure.md
+python -m datacenter_twin simulate --preset ai_cluster_utility_loss --format markdown --output outputs/ai-utility-loss.md
+```
+
+The first two commands use the 1,000 kW / 100 kWh reference cases; the latter two run the 50,000 kW / 5,000 kWh AI-cluster cases. The [course page](../tutorials/power-systems-course.md) lists all twelve browser lessons and the [continuity walkthrough](../tutorials/continuity-walkthrough.md) derives the reference battery and path calculations. Use a new output path or add `--force` if an output already exists.
+
+The AI preset definitions are in [`datacenter_twin/demo.py`](../../datacenter_twin/demo.py), and the CLI exposes them through the same `simulate --preset` command as the reference cases.
+
+## Assumptions and limits
+
+This case models one aggregate electrical IT load. It does not simulate individual GPU jobs, workload scheduling, throughput, cooling, temperature, battery aging, generator ramp/cooldown/fuel dynamics, transfer and switching transients, AC load flow, impedance-based sharing, protection coordination, harmonics, short-circuit or arc-flash studies, reliability probabilities, Tier claims, service-level claims, grid adequacy, facility safety, or certified uptime.
+
+The 50 MW and 5 MWh values are a 50× scale of the synthetic reference graph. The 0.90 battery efficiency, 0.95 distribution efficiency, path limits, event times, and fictional tariff are assumptions. They are not live prices, account quotes, selected equipment ratings, facility measurements, a performance benchmark, a legal-compliance result, or a site calibration. Unknown costs and unavailable quantities remain explicit.
+
+The browser has no shared simulation backend or client analytics, and the local API binds to loopback. No physical controls or external telemetry are used. Independent external technical review, formal security audit, facility calibration, FAT/SAT, and real-site validation are absent. A result can be internally consistent with the fixture and still be unsuitable as an engineering decision by itself.
+
+See the [schema-2 electrical contract](../contracts/electrical-v2.md), [synthetic provenance manifest](../../data/provenance/manifest.json), [Apache-2.0 license](../../LICENSE), [NOTICE](../../NOTICE), and [browser runtime licenses](../third-party/README.md).

--- a/docs/scenarios/glossary.md
+++ b/docs/scenarios/glossary.md
@@ -1,10 +1,10 @@
 # Electrical terms in the scenario catalog
 
-Use this glossary alongside the [five synthetic scenarios](index.md). The terms describe this uncalibrated software model; they do not establish equipment suitability, facility reliability, or certification.
+**Start with the terms used in the 50 MW AI-cluster question, then work through the reference calculation.**
 
 | Term | Unit or kind | Meaning in this model |
 | --- | --- | --- |
-| IT demand | kW | Electrical power requested by the aggregate IT load during an interval. It is an input assumption, not a prediction of workload or GPU performance. |
+| IT demand | kW | Electrical power requested by the aggregate IT load during an interval. It is an input assumption, not a prediction of workload, GPU throughput, or performance. |
 | Gross path capacity | kW | Maximum electrical power a declared path can carry before the model's distribution losses. A surviving path's gross capacity can therefore exceed the power delivered at the IT boundary. |
 | Distribution efficiency | Dimensionless ratio, greater than 0 and at most 1 | The fraction of dispatched gross electrical power delivered at the IT boundary. For example, 0.95 means 95% is delivered and 5% is accounted for as distribution loss. |
 | Stored battery energy | kWh | Energy held inside the modeled battery at a stated time, before discharge and distribution losses. Charging adds stored energy and discharging removes it. |
@@ -28,10 +28,35 @@ Unserved energy   = 335 kW × 1/6 h = 335/6 kWh = 55.833333… kWh
 
 The 335 kW figure describes the deficit during the outage. The 55.833333… kWh figure describes the total unserved energy over those ten minutes; the interval duration is necessary to convert between them.
 
-Reproduce the case from a source checkout with Python 3.12+:
+## Worked example: scaled aggregate AI-cluster reserve
+
+The browser teaching case scales the reference fixture by 50×:
+
+```text
+IT demand              = 50,000 kW = 50 MW
+initial stored energy  = 5,000 kWh = 5 MWh
+IT-boundary energy     = 5,000 kWh × 0.90 × 0.95 = 4,275 kWh
+ride-through duration  = 4,275 kWh / 50,000 kW × 3,600 s/h = 307.8 s
+depletion boundary    = 300 s + 307.8 s = 607.8 s
+```
+
+The scale-up preserves the synthetic ratios. It does not establish GPU throughput, grid adequacy, equipment selection, cooling performance, or facility calibration.
+
+Reproduce the 1 MW reference case from a source checkout with Python 3.12+:
 
 ```sh
 python -m datacenter_twin simulate --preset path_maintenance --format markdown
+python -m datacenter_twin simulate --preset generator_failure --format markdown
 ```
 
-The report should show 335 kW peak unserved power, 600 s unserved duration, 55.833333… kWh unserved IT energy, and a zero energy-balance residual. All ratings, demand, and efficiency here are synthetic assumptions; this is not a maintenance or equipment recommendation.
+The reference report should show 335 kW peak unserved power, 600 s unserved duration, 55.833333… kWh unserved IT energy, and a zero energy-balance residual for `path_maintenance`. The generator-failure report should show 307.8 s ride-through and depletion at 607.8 s. All ratings, demand, and efficiency here are synthetic assumptions.
+
+## Assumptions and limits
+
+The terms describe an uncalibrated software model. The 1 MW reference fixture uses 1,000 kW demand, 700 kW gross paths, 0.95 distribution efficiency, 100 kWh stored battery energy, 0.90 discharge efficiency, explicit event boundaries, and a fictional tariff. The 50 MW teaching case uses 50,000 kW and 5,000 kWh with the same ratios. These values are not selected-equipment ratings, live prices, a benchmark, a maintenance recommendation, a certification, legal-compliance evidence, or a real-site calibration.
+
+The model does not cover GPU throughput, workload prediction or queues, cooling, battery aging, temperature, generator ramp/cooldown/fuel dynamics, transfer and switching transients, AC load flow, impedance-based load sharing, protection coordination, harmonics, short-circuit and arc-flash studies, reliability probabilities, Tier claims, service-level claims, physical controls, or physical safety. It does not establish equipment suitability, facility reliability, or certification.
+
+The browser default uses exact JavaScript arithmetic. **Verify against Python** is an optional on-demand Pyodide cross-check when supplied by the deployed build; it is not needed for the initial browser result. The browser has no shared simulation backend or client analytics, and the API binds to loopback. Independent external review, formal security audit, facility measurements, validation data, and physical calibration are absent. Unknown costs and unavailable quantities remain explicit.
+
+Original code and synthetic fixtures use [Apache-2.0](../../LICENSE). See [NOTICE](../../NOTICE), [synthetic provenance](../../data/provenance/manifest.json), and [browser runtime licenses](../third-party/README.md).

--- a/docs/scenarios/index.md
+++ b/docs/scenarios/index.md
@@ -1,10 +1,25 @@
 # Scenario catalog
 
-![Datacenter Twin Lab visual concept for the champion roadmap](../images/datacenter-twin-lab-cover-v1.png)
+**Question:** what does an explicit power-continuity model show for a 50 MW aggregate AI-cluster load and for the smaller reference failures behind it?
 
-New to the electrical terms? Start with the [unit-aware glossary and kW/kWh example](glossary.md).
+The browser AI-cluster case uses **50,000 kW (50 MW)** IT demand and **5,000 kWh (5 MWh)** initial battery energy. With the same 0.90 discharge and 0.95 distribution efficiencies as the verified 1 MW fixture, the synthetic battery supplies IT for **307.8 s**, depletes at **607.8 s**, and utility restores service at **900 s**.
 
-These five presets are the bundled schema-2 synthetic continuity cases. Run them from the repository root with Python 3.12 or later:
+## Runnable cases
+
+| Preset | Start with this question | Event | Expected service result | Runnable route |
+| --- | --- | --- | --- | --- |
+| `ai_cluster_generator_failure` | How long does a 5 MWh reserve support a 50 MW aggregate load? | Utility and generator down at 300 s; restored at 900 s | 307.8 s ride-through; depletion at 607.8 s; the same scaled loss ratios as the 1 MW fixture | [Browser preset](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?preset=ai_cluster_generator_failure) |
+| [`normal`](normal.md) | What happens with healthy 1 MW supply? | No outage events | 500 kWh served; 0 kWh unserved; battery ends at 100 kWh | `python -m datacenter_twin simulate --preset normal` |
+| [`utility_loss`](utility_loss.md) | Can the 1 MW battery bridge generator startup? | Utility down at 300 s; utility restored at 900 s | Generator is requested at 300 s and ready at 330 s; all 500 kWh served; 0 s unserved | `python -m datacenter_twin simulate --preset utility_loss` |
+| [`generator_failure`](generator_failure.md) | What if the 1 MW generator also fails? | Utility and generator down at 300 s; restored at 900 s | Battery depletes at 607.8 s; 292.2 s unserved; 81.166666... kWh unserved; final battery 23.75 kWh | `python -m datacenter_twin simulate --preset generator_failure` |
+| [`path_maintenance`](path_maintenance.md) | Can one surviving path carry the 1 MW load? | Path A down at 300 s; restored at 900 s | Surviving path serves 665 kW; 335 kW unserved for 600 s; 55.833333... kWh unserved; battery remains 100 kWh | `python -m datacenter_twin simulate --preset path_maintenance` |
+| [`shared_domain`](shared_domain.md) | What if both paths share a failed control domain? | Shared controls down at 300 s; restored at 900 s | Both paths unavailable; 1,000 kW unserved for 600 s; 166.666666... kWh unserved | `python -m datacenter_twin simulate --preset shared_domain` |
+
+The AI-cluster row is the scaled browser teaching case; the five original rows remain the Python CLI regression fixtures. For a runnable browser first step, open the [GitHub Pages demo](https://mohammadrezwankhan.github.io/datacenter-twin-lab/); for the 1 MW route, use [`?preset=generator_failure`](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?preset=generator_failure).
+
+## Run the reference cases together
+
+Run the five original presets from the repository root with Python 3.12 or later:
 
 ```sh
 python -m datacenter_twin simulate --preset normal
@@ -14,24 +29,26 @@ python -m datacenter_twin simulate --preset path_maintenance
 python -m datacenter_twin simulate --preset shared_domain
 ```
 
-Each run reports a stable input hash, event log, interval energy ledger, units, warnings, and an explicit synthetic/uncalibrated boundary. The default fixture has a 1,000 kW IT request, 1,800 s duration, 0.95 distribution efficiency, 100 kWh initial battery energy, 0.90 discharge efficiency, and a 30 s generator start delay. The scenarios are teaching and regression fixtures; they do not represent equipment ratings, a facility, a workload, cooling, AC transients, certification, or physical controls.
+Each run reports a stable input hash, event log, interval energy ledger, units, warnings, and an explicit synthetic/uncalibrated boundary. For the five reference fixtures, the default input is a 1,000 kW IT request, 1,800 s duration, 0.95 distribution efficiency, 100 kWh initial battery energy, 0.90 discharge efficiency, and a 30 s generator start delay.
 
-For a runnable first lesson, see the [battery ride-through teaching notebook](../examples/battery-ride-through.ipynb) and its [running instructions](../examples/battery-ride-through.md). It independently derives the default `generator_failure` result and contrasts the charging-enabled and charging-disabled 50 kWh inputs.
+## Terms and support
 
-| Preset | Event | Expected service result | Hand calculation / check |
-| --- | --- | --- | --- |
-| [`normal`](normal.md) | No outage events | 500 kWh served; 0 kWh unserved; battery ends at 100 kWh | `1,000 kW × 0.5 h = 500 kWh`; gross input is `1,000 / 0.95 = 1,052.631... kW` |
-| [`utility_loss`](utility_loss.md) | Utility down at 300 s; utility restored at 900 s | Generator is requested at 300 s and ready at 330 s; all 500 kWh served; 0 s unserved | Battery bridges 30 s: `1,000 kW × 30/3,600 h = 8.333... kWh` at the IT boundary |
-| [`generator_failure`](generator_failure.md) | Utility and generator down at 300 s; restored at 900 s | Battery depletes at 607.8 s; 292.2 s unserved; 81.166666... kWh unserved; final battery 23.75 kWh | `100 × 0.90 × 0.95 = 85.5 kWh`; `85.5 / 1,000 × 3,600 = 307.8 s`; `900 − 607.8 = 292.2 s` |
-| [`path_maintenance`](path_maintenance.md) | Path A down at 300 s; restored at 900 s | Surviving path serves 665 kW; 335 kW unserved for 600 s; 55.833333... kWh unserved; battery remains 100 kWh | `700 kW × 0.95 = 665 kW`; `335 × 600/3,600 = 55.833333... kWh` |
-| [`shared_domain`](shared_domain.md) | Shared controls down at 300 s; restored at 900 s | Both paths unavailable; 1,000 kW unserved for 600 s; 166.666666... kWh unserved | `1,000 × 600/3,600 = 166.666666... kWh`; battery has no available path through the domain |
-
-The expected values above were checked by running the current engine and independently deriving the simple boundary calculations. Every verified run reported `energy_balance_residual_kwh: "0"`. See the relevant test names in [`tests/test_continuity.py`](../../tests/test_continuity.py).
+New to the electrical terms? Use the [unit-aware glossary and kW/kWh example](glossary.md) after the first run. For a complete hand calculation, see the [battery ride-through teaching notebook](../examples/battery-ride-through.ipynb), its [running instructions](../examples/battery-ride-through.md), and the [continuity walkthrough](../tutorials/continuity-walkthrough.md). The [quickstart](../quickstart.md) starts with the browser case before installation mechanics.
 
 ## Read the diagrams
 
-The diagrams show the same synthetic topology used by each preset. Events change asset or domain availability at explicit boundaries; they do not model switching transients or protection behavior.
+The diagrams show the same synthetic topology used by the reference presets. Events change asset or domain availability at explicit boundaries; they do not model switching transients or protection behavior.
 
 ## Propose a new case
 
 Use the [scenario proposal issue form](https://github.com/mohammadrezwankhan/datacenter-twin-lab/issues/new?template=scenario-proposal.yml), or start with the [beginner ideas](contribution-ideas.md). Include units, synthetic assumptions, a hand calculation, non-goals, and a testable expected result.
+
+## Assumptions and limits
+
+The scenario catalog models one synthetic aggregate IT load, explicit electrical topology, finite stored energy, generator delay/failure, conversion losses, path limits, shared-domain events, deterministic recovery, and exact energy accounting. It does not represent selected equipment, a facility, GPU throughput, grid adequacy, a workload, cooling, battery aging, generator fuel/ramp/cooldown, AC transients, load flow, impedance-based sharing, protection coordination, harmonics, short-circuit or arc-flash behavior, reliability probabilities, certification, physical controls, legal compliance, or a safety assessment.
+
+The 50 MW AI-cluster case scales the 1 MW / 100 kWh teaching fixture by 50× to 50,000 kW / 5,000 kWh and keeps the same ratios. All demand, capacity, efficiency, event-time, and fictional tariff values are synthetic assumptions. They are not live prices, account quotes, equipment ratings, a performance benchmark, or a real-site calibration. Unknown costs and unavailable quantities remain explicit.
+
+The browser default is exact JavaScript arithmetic; **Verify against Python** is an optional on-demand Pyodide cross-check when supplied by the deployed build. The browser has no shared simulation backend or client analytics, and the API binds to loopback. Independent external review, formal security audit, shared deployment, facility measurements, and validation data remain absent. The verified reference runs report `energy_balance_residual_kwh: "0"`; the AI-cluster row awaits the parent browser proof.
+
+Original code and synthetic fixtures use [Apache-2.0](../../LICENSE). See [NOTICE](../../NOTICE), [synthetic provenance](../../data/provenance/manifest.json), and [browser runtime licenses](../third-party/README.md).

--- a/docs/tutorials/continuity-walkthrough.md
+++ b/docs/tutorials/continuity-walkthrough.md
@@ -1,10 +1,13 @@
-# Surviving-path overload and finite battery ride-through
+# Surviving-path capacity and finite-battery ride-through
 
-![Datacenter Twin Lab visual concept for the champion roadmap](../images/datacenter-twin-lab-cover-v1.png)
+Two continuity results answer the first engineering questions:
 
+| Question | Synthetic result |
+| --- | --- |
+| Can one surviving 700 kW gross path carry a 1,000 kW IT request? | `700 kW × 0.95 = 665 kW` served, leaving `335 kW` unserved during the outage interval. |
+| How long does the 100 kWh reference battery serve the 1,000 kW load? | `100 kWh × 0.90 × 0.95 / 1,000 kW = 307.8 s`; with the outage starting at `300 s`, depletion is at `607.8 s`. |
 
-
-Maintainer: **Mohammad Rezwan Khan, maintainer of `datacenter-twin-lab`.** This tutorial uses the repository's synthetic electrical example; it is not an engineering approval or a real-site calibration.
+The browser's aggregate AI-cluster teaching case scales the same ratios to **50,000 kW (50 MW)** and **5,000 kWh (5 MWh)**, so its synthetic ride-through duration and event times are also **307.8 s** and **607.8 s**. These calculations describe a teaching fixture; they do not predict GPU throughput, grid adequacy, equipment selection, or site behavior.
 
 ## What this teaches
 
@@ -98,14 +101,33 @@ After restoration, the model can charge the battery from spare utility capacity.
 
 The unit test also contains a deliberately separate unity-efficiency fixture. It asserts depletion at 660 s because `100 kWh / 1,000 kW = 0.1 h = 360 s`, added to the 300 s outage start. This isolates finite-energy arithmetic; it should not be substituted for the default fixture's 0.95 and 0.90 efficiencies.
 
-## What the engine proves, and what it does not
+## Scale the arithmetic to the AI-cluster teaching case
 
-The implementation uses exact rational arithmetic, deterministic residual max-flow dispatch, explicit event boundaries, and an energy ledger. The source code is [`datacenter_twin/continuity.py`](../../datacenter_twin/continuity.py); the tests reconstruct the exported energy terms and require a zero energy-balance residual for every preset.
+The browser AI-cluster case scales the default request and initial battery by 50×:
 
-This is an electrical-only, single aggregate-load, synthetic experiment. It excludes cooling, workload queues, battery aging, temperature, generator ramp/cooldown/fuel dynamics, transfer and switching transients, AC load flow, impedance-based load sharing, protection coordination, harmonics, short-circuit and arc-flash studies, physical controls, reliability probabilities, Tier claims, service-level claims, and real-site calibration. The 700 kW paths, 100 kWh battery, efficiencies, event times, and fictional tariff are fixture inputs. They are not selected-equipment ratings, live prices, a benchmark, a certification, or legal compliance evidence.
+```text
+IT demand = 1,000 kW × 50 = 50,000 kW = 50 MW
+stored battery energy = 100 kWh × 50 = 5,000 kWh = 5 MWh
+IT-boundary energy = 5,000 kWh × 0.90 × 0.95 = 4,275 kWh
+ride-through time = 4,275 kWh / 50,000 kW × 3,600 s/h = 307.8 s
+```
+
+The scale-up preserves the synthetic model ratios. It does not establish GPU performance, grid adequacy, equipment ratings, cooling behavior, workload throughput, or site calibration.
+
+## What the engine proves
+
+The implementation uses exact rational arithmetic, deterministic residual max-flow dispatch, explicit event boundaries, and an energy ledger. The source code is [`datacenter_twin/continuity.py`](../../datacenter_twin/continuity.py); the tests reconstruct the exported energy terms and require a zero energy-balance residual for every verified reference preset.
+
+## Assumptions and limits
+
+This is an electrical-only, single aggregate-load, synthetic experiment. It excludes cooling, workload queues, battery aging, temperature, generator ramp/cooldown/fuel dynamics, transfer and switching transients, AC load flow, impedance-based load sharing, protection coordination, harmonics, short-circuit and arc-flash studies, physical controls, reliability probabilities, Tier claims, service-level claims, certification, legal-compliance evidence, and real-site calibration. The 700 kW paths, 100 kWh battery, efficiencies, event times, and fictional tariff are fixture inputs. They are not selected-equipment ratings or live prices.
+
+The browser has no shared simulation backend or client analytics; the API binds to loopback. The default browser calculation uses exact JavaScript arithmetic, while **Verify against Python** is an optional on-demand Pyodide cross-check when supplied by the deployed build. Neither path establishes physical accuracy. Independent external technical review, formal security audit, facility measurements, validation data, FAT/SAT, and calibrated alarms are absent.
+
+The examples teach inspectable software behavior. They do not establish a facility's reliability or physical validation. Unknown costs and unavailable quantities remain explicit.
 
 ## Reproduce and contribute
 
-Run both presets, inspect the interval beginning at 300 s, and compare the battery-depleted event with the hand calculation. If a result differs, open a [focused issue](https://github.com/mohammadrezwankhan/datacenter-twin-lab/issues) with the revision, command, input, expected value, and observed value. Contributions should preserve the synthetic assumptions and add an independently derived expectation.
+Run both reference presets, inspect the interval beginning at 300 s, and compare the battery-depleted event with the hand calculation. If a result differs, open a [focused issue](https://github.com/mohammadrezwankhan/datacenter-twin-lab/issues) with the revision, command, input, expected value, and observed value. Contributions should preserve the synthetic assumptions and add an independently derived expectation.
 
-The examples teach inspectable software behavior. They do not establish a facility's reliability or physical validation.
+The maintainer of `datacenter-twin-lab` supplies this tutorial from the repository's synthetic electrical example. It is not an engineering approval or a real-site calibration.

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,12 +1,35 @@
 # Tutorials
 
-![Datacenter Twin Lab visual concept for the champion roadmap](../images/datacenter-twin-lab-cover-v1.png)
+**Question:** what does a finite battery buy an aggregate AI-cluster load when utility and generator supply fail?
 
-Explore reproducible synthetic power-continuity scenarios and explain their energy accounting.
+The browser teaching case uses **50,000 kW (50 MW)** of synthetic IT demand and **5,000 kWh (5 MWh)** of initial battery energy. At the modeled 0.90 discharge and 0.95 distribution efficiencies, it supplies IT for **307.8 s** and reaches battery depletion at **607.8 s**. Start with that result, then use the smaller reference cases to inspect each part of the calculation.
 
-- [Start with the quickstart](../quickstart.md) to run your first simulation.
-- [Work through surviving-path overload and finite battery ride-through](continuity-walkthrough.md), with explicit assumptions and expected results.
-- [Browse the scenario catalog](../scenarios/index.md) to compare failures and recovery.
-- [Follow the recorded browser walkthrough](../examples/demo-walkthrough.md) to change reserve, replay a failure, and export results.
+| Runnable case | Question | Expected result | Where to run it |
+| --- | --- | --- | --- |
+| AI-cluster outage | How long does a 5 MWh reserve support a 50 MW aggregate load? | 307.8 s ride-through; depletion at 607.8 s; utility restoration at 900 s | [Browser demo](https://mohammadrezwankhan.github.io/datacenter-twin-lab/) · [AI-cluster scenario note](../scenarios/ai-cluster-50mw.md) |
+| Surviving path | Can one 700 kW gross path carry a 1 MW IT request? | 665 kW served; 335 kW unserved during the 600 s maintenance interval | [Continuity walkthrough](continuity-walkthrough.md) · [path_maintenance](../scenarios/path_maintenance.md) |
+| Finite battery | How long does the 1 MW / 100 kWh reference battery last? | 307.8 s ride-through; depletion at 607.8 s; recovery at 900 s | [Continuity walkthrough](continuity-walkthrough.md) · [generator_failure](../scenarios/generator_failure.md) |
+| Browser lesson | How do power, energy, and event boundaries relate? | Follow the first lesson, inspect the result, and optionally verify against Python | [Start power and energy](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=power-energy) · [course notes](power-systems-course.md) |
 
-These examples demonstrate software behavior for synthetic fixtures; they do not establish facility calibration or certification.
+## Begin the runnable journey
+
+- [Open the zero-install browser demo](https://mohammadrezwankhan.github.io/datacenter-twin-lab/) with the AI-cluster case.
+- [Start the 12-lesson browser course](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=power-energy) or read the [course guide](power-systems-course.md).
+- [Use the quickstart](../quickstart.md) when you need the optional Python, uv, released-wheel, or source workflow.
+- [Follow the recorded reference walkthrough](../examples/demo-walkthrough.md) to change reserve, replay a failure, and export a result; refresh the recorded asset if the controls or labels differ.
+
+The default browser path uses exact JavaScript arithmetic. Select **Verify against Python** only for the optional on-demand Pyodide cross-check. The initial browser result does not need the Python runtime.
+
+## Terms and support
+
+Use the [unit-aware glossary](../scenarios/glossary.md) after the first run to distinguish power in kW from accumulated energy in kWh. Browse the [scenario catalog](../scenarios/index.md) to compare failures and recovery, and use the [contribution ideas](../scenarios/contribution-ideas.md) for a bounded next step.
+
+## Assumptions and limits
+
+The 50 MW case is a synthetic 50× scale-up of the verified 1 MW / 100 kWh fixture. The current model covers one aggregate IT load, explicit topology, finite stored energy, conversion losses, path limits, shared-domain events, event boundaries, deterministic replay, and exact energy accounting. It does not establish GPU throughput, grid adequacy, equipment selection, facility calibration, cooling, workload queues, battery aging, generator ramp/cooldown/fuel dynamics, transfer and switching transients, AC load flow, impedance-based sharing, protection coordination, harmonics, short-circuit or arc-flash studies, reliability probabilities, Tier claims, service-level claims, certification, physical controls, or physical safety.
+
+The 1 MW reference fixture uses 1,000 kW IT demand, 1,800 s duration, 0.95 distribution efficiency, 100 kWh initial and maximum battery energy, 0.90 discharge efficiency, a 30 s generator start delay, 700 kW path capacities, and a fictional USD 0.10/kWh tariff. The 50 MW case scales demand and battery energy to 50,000 kW and 5,000 kWh with the same ratios. All ratings, demand, efficiency, event times, and tariff values are synthetic assumptions; they are not selected-equipment ratings, live prices, a benchmark, a certification, legal-compliance evidence, or a real-site calibration.
+
+These examples demonstrate software behavior for synthetic fixtures. They do not establish facility reliability or physical validation. The browser has no shared simulation backend or client analytics; the API binds to loopback. Independent external review, formal security audit, shared deployment, facility measurements, and validation data remain absent. Unknown costs and unavailable quantities stay explicit.
+
+Original code and synthetic fixtures use [Apache-2.0](../../LICENSE). See [NOTICE](../../NOTICE), [synthetic provenance](../../data/provenance/manifest.json), and [browser runtime licenses](../third-party/README.md).

--- a/docs/tutorials/power-systems-course.md
+++ b/docs/tutorials/power-systems-course.md
@@ -1,0 +1,80 @@
+# Power systems continuity course
+
+**Twelve short browser lessons for datacenter engineers learning how power, energy, storage, and continuity events fit together.**
+
+Start with the [power and energy lesson](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=power-energy), then use the lesson selector or **Next lesson**. Each lesson has one input, a challenge value, a worked answer, and a result you can inspect in the browser.
+
+## The headline result
+
+The AI-outage lesson uses a synthetic aggregate **50,000 kW (50 MW)** IT request and **5,000 kWh (5 MWh)** initial stored battery energy. Utility and generator supply fail at 300 s. With 0.90 battery discharge efficiency and 0.95 distribution efficiency:
+
+```text
+total modeled efficiency = 0.90 × 0.95 = 0.855
+IT-boundary reserve      = 5,000 kWh × 0.855 = 4,275 kWh
+ride-through             = 4,275 kWh / 50,000 kW × 3,600 s/h
+                         = 307.8 s
+battery depletion       = 300 s + 307.8 s = 607.8 s
+```
+
+The utility restoration event is at 900 s, leaving `900 − 607.8 = 292.2 s` after depletion. If the aggregate request stays at 50,000 kW, that interval contains:
+
+```text
+unserved IT energy = 50,000 kW × 292.2 s / 3,600 s/h
+                   = 4,058.333333... kWh
+```
+
+The calculation is a scaled teaching fixture. It answers how the declared reserve and efficiencies behave in this event sequence; it does not infer GPU throughput, job completion, grid adequacy, or site performance.
+
+## Run the lessons
+
+1. Open the [course at lesson 1](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=power-energy).
+2. Predict the challenge value shown by the lesson, then select **Try the challenge value** and **Run lesson**.
+3. Open **Show worked answer**, compare the displayed result and energy-balance residual, and move to the next lesson.
+4. Jump directly to [the 50 MW AI-outage lesson](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=ai-outage).
+
+The browser course needs no installation or account. The default calculation uses exact JavaScript arithmetic. **Verify against Python** is an optional action on a completed run; it loads the Python runtime only when selected.
+
+## Lesson map
+
+| # | Lesson and link | Question | Default → challenge | Expected check |
+| ---: | --- | --- | --- | --- |
+| 1 | [Power becomes energy](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=power-energy) | How much energy does a constant load request in half an hour? | 1,000 → 500 kW | `1,000 × 0.5 = 500 kWh`; the challenge gives 250 kWh. |
+| 2 | [Account for distribution losses](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=distribution-loss) | How much source power is needed to deliver 1,000 kW? | 0.95 → 0.90 ratio | `1,000 / 0.95 = 1,052.631... kW`; at 0.90 it is `1,111.111... kW`. |
+| 3 | [Calculate battery ride-through](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=ride-through) | Does half the stored energy give half the ride-through duration? | 100 → 50 kWh | Charging is disabled for this lesson: depletion is 607.8 s → 453.9 s. |
+| 4 | [Bridge generator startup](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=generator-delay) | What changes when startup takes 60 seconds instead of 30? | 30 → 60 s | Generator-ready event moves from 330 s to 360 s; the battery bridges both inputs. |
+| 5 | [Add a failed generator](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=generator-failure) | What changes if the generator cannot start? | Failed → available | Failed case depletes at 607.8 s with 292.2 s unserved; available generation starts at 330 s. |
+| 6 | [Check a surviving path](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=n-plus-one) | Can either path carry the whole 1 MW load? | 700 → 1,100 kW gross path | `700 × 0.95 = 665 kW`, leaving 335 kW; 1,100 kW gross supplies the full request after loss. |
+| 7 | [Expose shared control failures](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=shared-controls) | Can a shared control fault defeat both paths? | Shared → removed from Path B | Both paths unavailable gives 1,000 kW unmet; removing the dependency leaves 665 kW served. |
+| 8 | [Find a single point of failure](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=single-point) | What happens when the common main bus fails? | Failed → available | A 600 s outage gives `1,000 × 600/3,600 = 166.666... kWh` unserved. |
+| 9 | [Track energy before the outage](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=precharge) | Why can a 50 kWh case last longer when it charges first? | 100 → 0 kW charging | Pre-outage charging adds `100 × 300/3,600 × 0.95 = 7.9166... kWh`; depletion is 478.2675 s → 453.9 s. |
+| 10 | [Interrupt a 50 MW AI cluster](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=ai-outage) | How long can 5 MWh bridge a 50 MW load? | 5,000 → 2,500 kWh | Full reserve depletes at 607.8 s; the half-reserve challenge, with pre-outage charging, depletes at 478.2675 s. |
+| 11 | [Catch a sub-second service gap](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=recovery-deadline) | Does 57 kWh bridge recovery at 500 s? Does 58 kWh? | 57 → 58 kWh | 57 kWh depletes at 499.8135 s, leaving 0.1865 s unserved; 58 kWh bridges the event. |
+| 12 | [Separate PUE from continuity](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=pue) | How does assumed PUE change annual energy for the same 50 MW IT load? | 1.25 → 1.15 ratio | `50,000 × 8,760 × 1.25 = 547,500,000 kWh`; at 1.15 it is 503,700,000 kWh. |
+
+The lesson values above are the course defaults and challenge values. Other values can change event order, service gaps, and the reported ledger; read the result's assumptions and input hash with the number.
+
+## Reproduce the reference calculations with the CLI
+
+The public CLI accepts the original reference presets and the two AI-cluster presets. These commands use the documented `simulate` syntax and write Markdown reports to new paths:
+
+```sh
+python -m datacenter_twin simulate --preset generator_failure --format markdown --output outputs/course-generator-failure.md
+python -m datacenter_twin simulate --preset path_maintenance --format markdown --output outputs/course-path-maintenance.md
+python -m datacenter_twin simulate --preset ai_cluster_generator_failure --format markdown --output outputs/course-ai-generator-failure.md
+python -m datacenter_twin simulate --preset ai_cluster_utility_loss --format markdown --output outputs/course-ai-utility-loss.md
+python -m unittest discover -s tests -p test_continuity.py -v
+```
+
+The first report reproduces the 1 MW / 100 kWh calculation: 307.8 s of battery ride-through and depletion at 607.8 s. The second checks `700 kW × 0.95 = 665 kW` served and `335 kW` unserved during the 600 s maintenance interval. Choose new output paths or add `--force` when replacing an existing report.
+
+For the 50 MW case, use the browser's [AI-outage lesson](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=ai-outage) or either AI-cluster CLI command above. The lesson selects the implemented `ai_cluster_generator_failure` scenario and exposes the inputs and result without requiring a source checkout.
+
+## Assumptions and limits
+
+The lessons use synthetic electrical and planning exercises. The 50 MW examples represent one aggregate requested IT load. They do not model GPU jobs, workload queues, cooling, grid adequacy, AC transients, protection coordination, facility safety, reliability probabilities, selected equipment, or certified uptime. The N+1 lesson tests a path-capacity condition only. The PUE lesson is a separate annual energy calculation; do not add its overhead to the continuity losses a second time.
+
+The 1 MW reference fixture uses 1,000 kW IT demand, 100 kWh initial and maximum battery energy, 0.90 discharge efficiency, 0.95 distribution efficiency, a 30 s generator start delay, 700 kW gross paths, and explicit 300 s / 900 s events. The AI-cluster case scales the aggregate electrical quantities and storage by 50× while retaining the timing and modeled ratios. These are assumptions, not facility measurements, live prices, grid studies, or equipment ratings.
+
+No physical controls or external telemetry are used. The browser has no shared simulation backend or client analytics, and the local API binds to loopback. Independent external technical review, formal security audit, facility calibration, and real-site validation are absent. Lesson completion is not collected. Unknown costs and unavailable quantities remain explicit in exports.
+
+The course uses the repository's original synthetic fixtures and code under [Apache-2.0](../../LICENSE). See [NOTICE](../../NOTICE), [synthetic provenance](../../data/provenance/manifest.json), and [browser runtime licenses](../third-party/README.md).

--- a/docs/validation/browser-entry-measurement.json
+++ b/docs/validation/browser-entry-measurement.json
@@ -1,0 +1,40 @@
+{
+  "measured_at": "2026-09-12T14:59:03.988Z",
+  "scenario": "ai_cluster_generator_failure",
+  "environment": "Fresh Playwright Chromium context; loopback Vite preview; no network or CPU throttle",
+  "first_result_ms": 605,
+  "decoded_response_bytes": 322816,
+  "assets": [
+    {
+      "path": "/datacenter-twin-lab/",
+      "bytes": 3092
+    },
+    {
+      "path": "/datacenter-twin-lab/assets/index-Bkc640OZ.css",
+      "bytes": 16202
+    },
+    {
+      "path": "/datacenter-twin-lab/assets/index-Bk7KTKQ4.js",
+      "bytes": 242037
+    },
+    {
+      "path": "/datacenter-twin-lab/assets/worker-request-0zjDmk1J.js",
+      "bytes": 1032
+    },
+    {
+      "path": "/datacenter-twin-lab/assets/browser-client--ZI9whge.js",
+      "bytes": 228
+    },
+    {
+      "path": "/datacenter-twin-lab/assets/javascript-worker-Bc9svszt.js",
+      "bytes": 42262
+    },
+    {
+      "path": "/datacenter-twin-lab/demo-data.json",
+      "bytes": 17963
+    }
+  ],
+  "limitations": "One local observation; decoded payload, not a global visitor latency benchmark or compressed transfer size.",
+  "browser": "Playwright Chromium 153.0.8010.12 / Windows",
+  "application_worker_bytes": 42262
+}

--- a/docs/validation/reproducibility-capsule.md
+++ b/docs/validation/reproducibility-capsule.md
@@ -73,7 +73,7 @@ rounding and interval boundaries.
 
 The browser bridge is JSON-only and dispatches the existing pure engine inside
 a worker-compatible boundary. The bridge and loopback API tests compare all
-five presets, reject duplicate or oversized input, exercise report and sweep
+seven presets, reject duplicate or oversized input, exercise report and sweep
 contracts, verify deterministic hashes, and check HTML escaping. They do not
 establish browser-worker startup in every browser, physical electrical
 behavior, cooling behavior, workload prediction, or a shared deployment.

--- a/scripts/prepare_browser_demo.py
+++ b/scripts/prepare_browser_demo.py
@@ -13,6 +13,8 @@ from zipfile import ZipFile, ZipInfo, ZIP_DEFLATED
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 from datacenter_twin import __version__
+from datacenter_twin.demo import PRESETS, demo_scenario
+from datacenter_twin.catalog import load_catalog
 
 MODULES = ("__init__", "browser", "catalog", "contracts", "continuity", "demo",
            "engine", "reporting", "sensitivity", "topology")
@@ -55,6 +57,14 @@ def prepare() -> dict:
     for source in (ROOT / "docs/third-party").iterdir():
         if source.is_file():
             shutil.copyfile(source, output / "pyodide" / source.name)
+    # Small scenario inputs feed JavaScript; the Python archive stays optional.
+    demo_data = {"engine_version": __version__,
+                 "presets": [{"id": key, "name": name} for key, name in PRESETS.items()],
+                 "scenarios": {key: demo_scenario(key).to_dict() for key in PRESETS}}
+    (output / "demo-data.json").write_text(
+        json.dumps(demo_data, separators=(",", ":")) + "\n", encoding="utf-8")
+    (output / "catalog.json").write_text(
+        json.dumps(load_catalog(), separators=(",", ":")) + "\n", encoding="utf-8")
     (output / ".nojekyll").write_text("", encoding="utf-8")
     print(json.dumps({"engine_version": __version__, "archive_sha256": manifest["archive_sha256"],
                       "source_files": len(entries), "output": str(output)}))

--- a/scripts/verify_distribution.py
+++ b/scripts/verify_distribution.py
@@ -78,10 +78,24 @@ def main() -> int:
             "import json; from datacenter_twin.catalog import load_catalog; print(json.dumps(load_catalog()))"))
         if {offer["provider"] for offer in catalog["cloud_offers"]} != {"AWS", "Azure", "OCI"}:
             raise RuntimeError("Installed catalogue is incomplete")
+        for preset in ("ai_cluster_utility_loss", "ai_cluster_generator_failure"):
+            ai_run = json.loads(execute(str(console), "simulate", "--preset", preset))["result"]
+            if ai_run["scenario"]["it_demand_kw"] != "50000":
+                raise RuntimeError("Installed AI preset lost the aggregate 50 MW demand")
+            if ai_run["summary"]["energy_balance_residual_kwh"] != "0":
+                raise RuntimeError("Installed AI preset failed exact energy accounting")
+            if preset.endswith("utility_loss") and ai_run["summary"]["unserved_it_kwh"] != "0":
+                raise RuntimeError("Installed 50 MW pickup case failed to bridge startup")
+            if preset.endswith("generator_failure") and not any(
+                event["action"] == "battery_depleted" and event["at_s"] == "607.8"
+                for event in ai_run["events"]
+            ):
+                raise RuntimeError("Installed 50 MW failure case has incorrect depletion")
         print(json.dumps({"wheel": wheel.name, "version": identity["runtime"],
                           "python": sys.version.split()[0], "installed_outside_checkout": True,
                           "network_free_install": True, "module_and_console": "passed",
-                          "continuity_and_catalogue": "passed", "dashboard_bundled": bool(web_files)}))
+                          "continuity_and_catalogue": "passed", "ai_presets": "passed",
+                          "dashboard_bundled": bool(web_files)}))
     return 0
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,7 +2,7 @@ import importlib.util
 import unittest
 from pathlib import Path
 
-from datacenter_twin.demo import demo_scenario
+from datacenter_twin.demo import PRESETS, demo_scenario
 from datacenter_twin.continuity import simulate_continuity
 
 HAS_API = importlib.util.find_spec("fastapi") is not None and importlib.util.find_spec("httpx") is not None
@@ -31,13 +31,26 @@ class ApiTests(unittest.TestCase):
         self.assertIn("missing asset", response.json()["error"])
 
     def test_host_and_cross_origin_boundaries(self):
-        self.assertEqual(self.client.get("/api/v1/health", headers={"host":"untrusted.example"}).status_code,400)
-        response = self.client.options("/api/v1/simulations", headers={"origin":"https://untrusted.example", "access-control-request-method":"POST"})
-        self.assertEqual(response.status_code,400)
+        response = self.client.get(
+            "/api/v1/health", headers={"host": "untrusted.example"}
+        )
+        self.assertEqual(response.status_code, 400)
+        response = self.client.options(
+            "/api/v1/simulations",
+            headers={
+                "origin": "https://untrusted.example",
+                "access-control-request-method": "POST",
+            },
+        )
+        self.assertEqual(response.status_code, 400)
 
     def test_duplicate_keys_and_large_inputs(self):
         for content in (b'{"schema_version":2,"schema_version":1}', b" "*(4*1024*1024+1)):
-            response = self.client.post("/api/v1/simulations", content=content, headers={"content-type":"application/json"})
+            response = self.client.post(
+                "/api/v1/simulations",
+                content=content,
+                headers={"content-type": "application/json"},
+            )
             self.assertEqual(response.status_code,422)
 
     def test_no_physical_actuation_routes(self):
@@ -46,7 +59,11 @@ class ApiTests(unittest.TestCase):
 
     def test_presets_and_security_headers(self):
         response = self.client.get("/api/v1/presets")
-        self.assertEqual(len(response.json()),5)
+        self.assertEqual(len(response.json()), 7)
+        self.assertEqual(
+            response.json(),
+            [{"id": key, "name": name} for key, name in PRESETS.items()],
+        )
         self.assertEqual(response.headers["x-content-type-options"],"nosniff")
         self.assertEqual(response.headers["cache-control"],"no-store")
 
@@ -61,10 +78,16 @@ class ApiTests(unittest.TestCase):
         from datacenter_twin.engine import simulate
         path = Path(__file__).resolve().parents[1]/"data/scenarios/baseline-1mw.json"
         scenario = load_scenario(path)
-        self.assertEqual(self.client.post("/api/v1/planning",json=scenario.to_dict()).json(),simulate(scenario))
+        response = self.client.post("/api/v1/planning", json=scenario.to_dict())
+        self.assertEqual(response.json(), simulate(scenario))
 
     def test_malformed_payloads_are_contract_errors(self):
         for content in (b"[]", b"null", b"\xff", b"["*20000+b"]"*20000):
-            response = self.client.post("/api/v1/simulations",content=content,headers={"content-type":"application/json"})
-            self.assertEqual(response.status_code,422,response.text)
-        self.assertEqual(self.client.post("/api/v1/simulations",content=b"{}").status_code,422)
+            response = self.client.post(
+                "/api/v1/simulations",
+                content=content,
+                headers={"content-type": "application/json"},
+            )
+            self.assertEqual(response.status_code, 422, response.text)
+        response = self.client.post("/api/v1/simulations", content=b"{}")
+        self.assertEqual(response.status_code, 422)

--- a/tests/test_browser_bridge.py
+++ b/tests/test_browser_bridge.py
@@ -1,16 +1,25 @@
 import importlib.util
 import json
 from dataclasses import replace
+from pathlib import Path
 import unittest
 
 from datacenter_twin.browser import dispatch_json, scenario_report, scenario_sweep
 from datacenter_twin.continuity import simulate_continuity
-from datacenter_twin.contracts import InputError, MAX_SCENARIO_BYTES
+from datacenter_twin.contracts import InputError, MAX_SCENARIO_BYTES, load_scenario
 from datacenter_twin.demo import PRESETS, demo_scenario
+from datacenter_twin.engine import simulate
 from datacenter_twin.sensitivity import sweep_continuity
 
 
 class BrowserBridgeTests(unittest.TestCase):
+    def test_planning_dispatch_matches_native_engine(self):
+        scenario_path = Path(__file__).resolve().parents[1] / "data/scenarios/baseline-1mw.json"
+        scenario = load_scenario(scenario_path)
+        expected = simulate(scenario)
+        adapted = json.loads(dispatch_json("planning", json.dumps(scenario.to_dict())))
+        self.assertEqual(adapted, expected)
+
     def test_native_and_json_adapter_match_for_every_preset(self):
         for preset in PRESETS:
             with self.subTest(preset=preset):
@@ -40,7 +49,11 @@ class BrowserBridgeTests(unittest.TestCase):
         self.assertIn("&lt;script&gt;", report["text"])
         self.assertNotIn("<script>", report["text"])
 
-        sweep_payload = {"scenario": scenario.to_dict(), "parameter": "battery_initial_kwh", "values": [0, 50, 100]}
+        sweep_payload = {
+            "scenario": scenario.to_dict(),
+            "parameter": "battery_initial_kwh",
+            "values": [0, 50, 100],
+        }
         expected = sweep_continuity(scenario, "battery_initial_kwh", [0, 50, 100])
         adapted_sweep = json.loads(dispatch_json("sweeps", json.dumps(sweep_payload)))
         self.assertEqual(adapted_sweep, expected)
@@ -54,8 +67,12 @@ class BrowserBridgeTests(unittest.TestCase):
         for payload in invalid_reports:
             with self.subTest(payload=payload), self.assertRaises(InputError):
                 scenario_report(payload)
-        for payload in ({"scenario": scenario}, {"scenario": scenario, "parameter": "battery_initial_kwh", "values": []},
-                        {"scenario": scenario, "parameter": [], "values": [1]}):
+        invalid_sweeps = (
+            {"scenario": scenario},
+            {"scenario": scenario, "parameter": "battery_initial_kwh", "values": []},
+            {"scenario": scenario, "parameter": [], "values": [1]},
+        )
+        for payload in invalid_sweeps:
             with self.subTest(payload=payload), self.assertRaises(InputError):
                 scenario_sweep(payload)
 
@@ -84,16 +101,31 @@ class BrowserHttpTests(unittest.TestCase):
         self.assertNotIn("<img", report["text"])
         self.assertEqual(report["run_id"], simulate_continuity(scenario).run_id)
 
-        sweep_payload = {"scenario": scenario.to_dict(), "parameter": "battery_initial_kwh", "values": [0, 50, 100]}
+        sweep_payload = {
+            "scenario": scenario.to_dict(),
+            "parameter": "battery_initial_kwh",
+            "values": [0, 50, 100],
+        }
         response = self.client.post("/api/v1/sweeps", json=sweep_payload)
         self.assertEqual(response.status_code, 200, response.text)
         result = response.json()
         self.assertEqual(result, scenario_sweep(sweep_payload))
         self.assertEqual(result["base_input_sha256"], simulate_continuity(scenario).input_sha256)
 
-        for payload in ({"scenario": scenario.to_dict()}, {"scenario": scenario.to_dict(), "format": "xml"}):
+        invalid_reports = (
+            {"scenario": scenario.to_dict()},
+            {"scenario": scenario.to_dict(), "format": "xml"},
+        )
+        for payload in invalid_reports:
             self.assertEqual(self.client.post("/api/v1/reports", json=payload).status_code, 422)
-        for payload in ({"scenario": scenario.to_dict()},
-                        {"scenario": scenario.to_dict(), "parameter": "battery_initial_kwh", "values": []},
-                        {"scenario": scenario.to_dict(), "parameter": "battery_initial_kwh", "values": ["1", "1.0"]}):
+        invalid_sweeps = (
+            {"scenario": scenario.to_dict()},
+            {"scenario": scenario.to_dict(), "parameter": "battery_initial_kwh", "values": []},
+            {
+                "scenario": scenario.to_dict(),
+                "parameter": "battery_initial_kwh",
+                "values": ["1", "1.0"],
+            },
+        )
+        for payload in invalid_sweeps:
             self.assertEqual(self.client.post("/api/v1/sweeps", json=payload).status_code, 422)

--- a/tests/test_continuity.py
+++ b/tests/test_continuity.py
@@ -22,27 +22,42 @@ class TopologyTests(unittest.TestCase):
             data = deepcopy(self.data)
             if alteration == "duplicate": data["assets"][1]["id"] = "utility"
             elif alteration == "missing": data["dependencies"][0]["target"] = "missing"
-            elif alteration == "cycle": data["dependencies"].append({"source":"it-bus","target":"main-bus","relation":"feeds"})
-            elif alteration == "charges": data["dependencies"] = [edge for edge in data["dependencies"] if edge["relation"] != "charges"]
-            else: data["dependencies"] = [edge for edge in data["dependencies"] if edge["source"] != "generator"]
-            with self.subTest(alteration=alteration), self.assertRaises(InputError): SiteScenario.from_dict(data)
+            elif alteration == "cycle":
+                data["dependencies"].append(
+                    {"source": "it-bus", "target": "main-bus", "relation": "feeds"}
+                )
+            elif alteration == "charges":
+                data["dependencies"] = [
+                    edge for edge in data["dependencies"] if edge["relation"] != "charges"
+                ]
+            else:
+                data["dependencies"] = [
+                    edge for edge in data["dependencies"] if edge["source"] != "generator"
+                ]
+            with self.subTest(alteration=alteration), self.assertRaises(InputError):
+                SiteScenario.from_dict(data)
 
     def test_units_bounds_and_invalid_metadata(self):
         for values in ({"distribution_efficiency":"1.01"}, {"battery_initial_kwh":"101"},
                        {"duration_s":True}, {"duration_s":86400,"step_s":1}, {"schema_version":1},
                        {"tariff_per_kwh":"NaN"}, {"it_demand_kw":-1}, {"currency":"GBP"}):
-            with self.subTest(values=values), self.assertRaises(InputError): SiteScenario.from_dict({**self.data, **values})
+            with self.subTest(values=values), self.assertRaises(InputError):
+                SiteScenario.from_dict({**self.data, **values})
         self.data["assets"][0]["capacity_kva"] = 1500
         with self.assertRaises(InputError): SiteScenario.from_dict(self.data)
 
     def test_event_targets_and_end_boundary(self):
         for event in (Event(0,"asset_down","missing",None), Event(1800,"asset_down","utility",None),
                       Event(0,"set_demand","battery",10)):
-            with self.subTest(event=event), self.assertRaises(InputError): replace(demo_scenario(), events=(event,))
+            with self.subTest(event=event), self.assertRaises(InputError):
+                replace(demo_scenario(), events=(event,))
 
     def test_requires_cycle_is_rejected(self):
         base = demo_scenario()
-        edges = base.dependencies + (Dependency("path-a","path-b","requires"), Dependency("path-b","path-a","requires"))
+        edges = base.dependencies + (
+            Dependency("path-a", "path-b", "requires"),
+            Dependency("path-b", "path-a", "requires"),
+        )
         with self.assertRaisesRegex(InputError,"requires cycle"): replace(base, dependencies=edges)
 
     def test_charging_path_and_battery_power_limits(self):
@@ -50,7 +65,12 @@ class TopologyTests(unittest.TestCase):
         with self.assertRaisesRegex(InputError,"electrical power rating"):
             replace(base, battery_charge_kw=1201)
         bus = Asset("isolated", "Isolated bus", "bus", 100, ("isolated",), ("test",))
-        edges = tuple(Dependency("isolated","battery","charges") if e.relation == "charges" else e for e in base.dependencies)
+        edges = tuple(
+            Dependency("isolated", "battery", "charges")
+            if edge.relation == "charges"
+            else edge
+            for edge in base.dependencies
+        )
         with self.assertRaisesRegex(InputError,"charging bus"):
             replace(base, assets=base.assets+(bus,), dependencies=edges)
 
@@ -102,14 +122,27 @@ class ContinuityTests(unittest.TestCase):
 
     def test_requires_dependencies_propagate_unavailability(self):
         base = demo_scenario("normal")
-        run = simulate_continuity(replace(base, dependencies=base.dependencies+(Dependency("path-a","path-b","requires"),),
-                                         events=(Event(0,"asset_down","path-a",None),))).to_dict()
+        run = simulate_continuity(
+            replace(
+                base,
+                dependencies=base.dependencies
+                + (Dependency("path-a", "path-b", "requires"),),
+                events=(Event(0, "asset_down", "path-a", None),),
+            )
+        ).to_dict()
         self.assertEqual(run["intervals"][0]["served_it_kw"], "0")
 
     def test_charging_uses_only_spare_grid_power(self):
         base = demo_scenario("normal")
         assets = tuple(replace(a,capacity_kw=1000) if a.kind == "utility" else a for a in base.assets)
-        run = simulate_continuity(replace(base, assets=assets, distribution_efficiency=1, battery_initial_kwh=50)).to_dict()
+        run = simulate_continuity(
+            replace(
+                base,
+                assets=assets,
+                distribution_efficiency=1,
+                battery_initial_kwh=50,
+            )
+        ).to_dict()
         self.assertEqual(run["summary"]["battery_final_kwh"], "50")
         self.assertTrue(all(row["battery_charge_kw"] == "0" for row in run["intervals"]))
 
@@ -121,20 +154,93 @@ class ContinuityTests(unittest.TestCase):
 
     def test_energy_balance_all_presets_and_battery_bounds(self):
         for preset in PRESETS:
-            run = self.run_case(preset)
+            scenario = demo_scenario(preset)
+            run = simulate_continuity(scenario).to_dict()
             for row in run["intervals"]:
                 with self.subTest(preset=preset, at=row["start_s"]):
                     energy = {key:F(value) for key,value in row["energy"].items()}
-                    self.assertLess(abs(energy["requested_it_kwh"]-energy["served_it_kwh"]-energy["unserved_it_kwh"]), F(1,10**80))
+                    self.assertLess(
+                        abs(
+                            energy["requested_it_kwh"]
+                            - energy["served_it_kwh"]
+                            - energy["unserved_it_kwh"]
+                        ),
+                        F(1, 10**80),
+                    )
                     self.assertEqual(row["energy_balance_residual_kwh"], "0")
                     # Independently reconstruct the boundary from exported terms, not its residual field.
                     incoming = energy["grid_kwh"] + energy["generator_kwh"]
                     accounted = sum(energy[key] for key in ("served_it_kwh", "battery_stored_change_kwh",
                         "distribution_loss_kwh", "battery_charge_loss_kwh", "battery_discharge_loss_kwh"))
                     self.assertLess(abs(incoming-accounted), F(1,10**80))
-                    self.assertLess(abs(F(row["battery_end_kwh"])-F(row["battery_start_kwh"])-energy["battery_stored_change_kwh"]), F(1,10**80))
-                    self.assertTrue(0 <= F(row["battery_end_kwh"]) <= 100)
+                    self.assertLess(
+                        abs(
+                            F(row["battery_end_kwh"])
+                            - F(row["battery_start_kwh"])
+                            - energy["battery_stored_change_kwh"]
+                        ),
+                        F(1, 10**80),
+                    )
+                    self.assertTrue(
+                        0 <= F(row["battery_end_kwh"]) <= F(scenario.battery_capacity_kwh)
+                    )
             self.assertEqual(run["summary"]["energy_balance_residual_kwh"], "0")
+
+    def test_ai_cluster_presets_scale_aggregate_electrical_inputs(self):
+        base_cases = {
+            "ai_cluster_utility_loss": "utility_loss",
+            "ai_cluster_generator_failure": "generator_failure",
+        }
+        scaled_summary_fields = (
+            "requested_it_kwh",
+            "served_it_kwh",
+            "unserved_it_kwh",
+            "grid_kwh",
+            "generator_kwh",
+            "distribution_loss_kwh",
+            "battery_charge_loss_kwh",
+            "battery_discharge_loss_kwh",
+            "battery_stored_change_kwh",
+        )
+        for scaled_preset, base_preset in base_cases.items():
+            with self.subTest(preset=scaled_preset):
+                scenario = demo_scenario(scaled_preset)
+                base_run = self.run_case(base_preset)
+                scaled_run = simulate_continuity(scenario).to_dict()
+                self.assertEqual(scenario.it_demand_kw, 50000)
+                self.assertEqual(scenario.it_capacity_kw, 50000)
+                self.assertEqual(scenario.battery_initial_kwh, 5000)
+                self.assertEqual(scenario.battery_capacity_kwh, 5000)
+                self.assertEqual(scenario.battery_charge_kw, 5000)
+                self.assertIn("SYN-AI-50MW-001", scenario.source_ids)
+                for field in scaled_summary_fields:
+                    self.assertLess(
+                        abs(F(scaled_run["summary"][field]) - F(base_run["summary"][field]) * 50),
+                        F(1, 10**80),
+                    )
+                self.assertEqual(
+                    scaled_run["summary"]["unserved_duration_s"],
+                    base_run["summary"]["unserved_duration_s"],
+                )
+                self.assertEqual(scaled_run["summary"]["energy_balance_residual_kwh"], "0")
+
+    def test_ai_cluster_generator_pickup_bridges_thirty_seconds(self):
+        run = self.run_case("ai_cluster_utility_loss")
+        during_start = next(row for row in run["intervals"] if row["start_s"] == "320")
+        after_start = next(row for row in run["intervals"] if row["start_s"] == "330")
+        self.assertEqual(during_start["end_s"], "330")
+        self.assertEqual(during_start["served_it_kw"], "50000")
+        self.assertGreater(F(during_start["battery_discharge_kw"]), 0)
+        self.assertEqual(after_start["asset_states"]["generator"], "running")
+        self.assertEqual(after_start["battery_discharge_kw"], "0")
+
+    def test_ai_cluster_generator_failure_depletes_at_scaled_ride_through_boundary(self):
+        run = self.run_case("ai_cluster_generator_failure")
+        depletion = next(event for event in run["events"] if event["action"] == "battery_depleted")
+        self.assertEqual(depletion["at_s"], "607.8")
+        depleted = next(row for row in run["intervals"] if row["start_s"] == "607.8")
+        self.assertEqual(depleted["battery_start_kwh"], "0")
+        self.assertEqual(depleted["served_it_kw"], "0")
 
     def test_unknown_generator_cost_is_not_free(self):
         run = self.run_case("utility_loss")
@@ -165,7 +271,16 @@ class ContinuityTests(unittest.TestCase):
 
     def test_residual_network_reroutes_to_avoid_greedy_path_failure(self):
         network = FlowNetwork()
-        for a,b,capacity in [("SOURCE","a",1),("SOURCE","b",1),("a","c",1),("a","d",1),("b","c",1),("c","SINK",1),("d","SINK",1)]:
+        edges = [
+            ("SOURCE", "a", 1),
+            ("SOURCE", "b", 1),
+            ("a", "c", 1),
+            ("a", "d", 1),
+            ("b", "c", 1),
+            ("c", "SINK", 1),
+            ("d", "SINK", 1),
+        ]
+        for a, b, capacity in edges:
             network.add(a,b,F(capacity))
         network.augment()
         self.assertEqual(network.flow("c","SINK")+network.flow("d","SINK"),2)

--- a/tests/test_course_lessons.py
+++ b/tests/test_course_lessons.py
@@ -1,0 +1,268 @@
+"""Independent native expectations for the twelve browser course lessons."""
+
+from dataclasses import replace
+from fractions import Fraction
+import unittest
+
+from datacenter_twin.continuity import simulate_continuity
+from datacenter_twin.contracts import Scenario
+from datacenter_twin.demo import demo_scenario
+from datacenter_twin.engine import simulate
+from datacenter_twin.topology import Event
+
+
+
+
+LESSON_CASES = (
+    {
+        "id": "power-energy",
+        "preset": "normal",
+        "field": "it_demand_kw",
+        "initial": "1000",
+        "challenge": "500",
+        "result_key": "requested_it_kwh",
+        "expected_initial": "500",
+        "expected_challenge": "250",
+    },
+    {
+        "id": "distribution-loss",
+        "preset": "normal",
+        "field": "distribution_efficiency",
+        "initial": "0.95",
+        "challenge": "0.90",
+        "result_key": "grid_kwh",
+        "expected_initial": "526.315789473684210526315789473684210526315789473684210526315789",
+        "expected_challenge": "555.555555555555555555555555555555555555555555555555555555555555",
+    },
+    {
+        "id": "ride-through",
+        "preset": "generator_failure",
+        "field": "battery_initial_kwh",
+        "initial": "100",
+        "challenge": "50",
+        "result_key": "battery_depleted",
+        "expected_initial": "607.8",
+        "expected_challenge": "453.9",
+    },
+    {
+        "id": "generator-delay",
+        "preset": "utility_loss",
+        "field": "generator_start_delay_s",
+        "initial": "30",
+        "challenge": "60",
+        "result_key": "generator_ready",
+        "expected_initial": "330",
+        "expected_challenge": "360",
+    },
+    {
+        "id": "generator-failure",
+        "preset": "generator_failure",
+        "field": "generator_available",
+        "initial": "0",
+        "challenge": "1",
+        "result_key": "unserved_duration_s",
+        "expected_initial": "292.2",
+        "expected_challenge": "0",
+    },
+    {
+        "id": "n-plus-one",
+        "preset": "path_maintenance",
+        "field": "path_capacity",
+        "initial": "700",
+        "challenge": "1100",
+        "result_key": "peak_unserved_kw",
+        "expected_initial": "335",
+        "expected_challenge": "0",
+    },
+    {
+        "id": "shared-controls",
+        "preset": "shared_domain",
+        "field": "shared_controls",
+        "initial": "1",
+        "challenge": "0",
+        "result_key": "peak_unserved_kw",
+        "expected_initial": "1000",
+        "expected_challenge": "335",
+    },
+    {
+        "id": "single-point",
+        "preset": "normal",
+        "field": "main_bus_available",
+        "initial": "0",
+        "challenge": "1",
+        "result_key": "unserved_it_kwh",
+        "expected_initial": "166.666666666666666666666666666666666666666666666666666666666666",
+        "expected_challenge": "0",
+    },
+    {
+        "id": "precharge",
+        "preset": "generator_failure",
+        "field": "battery_charge_kw",
+        "initial": "100",
+        "challenge": "0",
+        "result_key": "battery_depleted",
+        "expected_initial": "478.2675",
+        "expected_challenge": "453.9",
+    },
+    {
+        "id": "ai-outage",
+        "preset": "ai_cluster_generator_failure",
+        "field": "battery_initial_kwh",
+        "initial": "5000",
+        "challenge": "2500",
+        "result_key": "battery_depleted",
+        "expected_initial": "607.8",
+        "expected_challenge": "478.2675",
+    },
+    {
+        "id": "recovery-deadline",
+        "preset": "generator_failure",
+        "field": "battery_initial_kwh",
+        "initial": "57",
+        "challenge": "58",
+        "result_key": "unserved_duration_s",
+        "expected_initial": "0.1865",
+        "expected_challenge": "0",
+    },
+    {
+        "id": "pue",
+        "preset": "normal",
+        "field": "pue",
+        "initial": "1.25",
+        "challenge": "1.15",
+        "result_key": "facility_energy_kwh",
+        "expected_initial": "547500000",
+        "expected_challenge": "503700000",
+    },
+)
+
+
+def _scenario_for_lesson(case: dict, value: str):
+    """Apply lesson changes independently of the TypeScript transformation."""
+    lesson_id = case["id"]
+    scenario = demo_scenario(case["preset"])
+    if lesson_id == "power-energy":
+        return replace(scenario, it_demand_kw=value)
+    if lesson_id == "distribution-loss":
+        return replace(scenario, distribution_efficiency=value)
+    if lesson_id == "ride-through":
+        return replace(scenario, battery_initial_kwh=value, battery_charge_kw=0)
+    if lesson_id == "generator-delay":
+        return replace(scenario, generator_start_delay_s=int(value))
+    if lesson_id == "generator-failure":
+        if int(value) == 1:
+            scenario = replace(
+                scenario,
+                events=tuple(event for event in scenario.events if event.target != "generator"),
+            )
+        return scenario
+    if lesson_id == "n-plus-one":
+        assets = tuple(
+            replace(asset, capacity_kw=value)
+            if asset.kind == "distribution"
+            else asset
+            for asset in scenario.assets
+        )
+        return replace(scenario, assets=assets)
+    if lesson_id == "shared-controls":
+        if int(value) == 0:
+            assets = tuple(
+                replace(
+                    asset,
+                    failure_domains=tuple(
+                        domain
+                        for domain in asset.failure_domains
+                        if domain != "shared-controls"
+                    ),
+                )
+                if asset.id == "path-b"
+                else asset
+                for asset in scenario.assets
+            )
+            scenario = replace(scenario, assets=assets)
+        return scenario
+    if lesson_id == "single-point":
+        events = () if int(value) == 1 else (
+            Event(300, "asset_down", "main-bus", None),
+            Event(900, "asset_up", "main-bus", None),
+        )
+        return replace(scenario, events=events)
+    if lesson_id == "precharge":
+        return replace(scenario, battery_initial_kwh=50, battery_charge_kw=value)
+    if lesson_id == "ai-outage":
+        return replace(scenario, battery_initial_kwh=value)
+    if lesson_id == "recovery-deadline":
+        events = tuple(
+            replace(event, at_s=500)
+            if event.target == "utility" and event.action == "asset_up"
+            else event
+            for event in scenario.events
+        )
+        return replace(scenario, battery_initial_kwh=value, events=events)
+    raise AssertionError(f"Unhandled lesson {lesson_id}")
+
+
+def _planning_result(pue: str) -> dict:
+    scenario = Scenario.from_dict(
+        {
+            "schema_version": 1,
+            "id": "course-pue",
+            "name": "50 MW annual energy planning",
+            "currency": "USD",
+            "it_capacity_kw": "50000",
+            "tariff_per_kwh": None,
+            "price_status": "unknown",
+            "assumption_date": "2026-09-12",
+            "source_ids": ["EDU-POWER-001"],
+            "segments": [
+                {
+                    "label": "Assumed constant annual load",
+                    "hours": "8760",
+                    "it_load_kw": "50000",
+                    "assumed_pue": pue,
+                }
+            ],
+        }
+    )
+    return simulate(scenario)
+
+
+class CourseLessonTests(unittest.TestCase):
+    def assert_quantity_close(self, actual: str, expected: str) -> None:
+        difference = abs(Fraction(actual) - Fraction(expected))
+        # Export formatting keeps 100 decimal digits; the table records enough
+        # digits to check the independent result without copying that formatter.
+        self.assertLess(difference, Fraction(1, 10**50))
+
+    def assert_lesson_result(self, case: dict, value: str, expected: str) -> None:
+        if case["id"] == "pue":
+            result = _planning_result(value)
+            self.assert_quantity_close(result[case["result_key"]], expected)
+            return
+        result = simulate_continuity(_scenario_for_lesson(case, value)).to_dict()
+        if case["result_key"] in ("battery_depleted", "generator_ready"):
+            action = (
+                "battery_depleted"
+                if case["result_key"] == "battery_depleted"
+                else "generator_start_requested"
+            )
+            event = next(item for item in result["events"] if item["action"] == action)
+            actual = event["at_s"] if action == "battery_depleted" else event["ready_at_s"]
+        else:
+            actual = result["summary"][case["result_key"]]
+        self.assert_quantity_close(actual, expected)
+
+    def test_defaults_and_challenges_match_independent_native_expectations(self):
+        for case in LESSON_CASES:
+            with self.subTest(lesson=case["id"], value="initial"):
+                self.assert_lesson_result(
+                    case, case["initial"], case["expected_initial"]
+                )
+            with self.subTest(lesson=case["id"], value="challenge"):
+                self.assert_lesson_result(
+                    case, case["challenge"], case["expected_challenge"]
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A first-time visitor previously downloaded the Python runtime before seeing a calculation. This change opens a 50 MW aggregate electrical outage in an exact JavaScript worker and offers the reference Python engine as an explicit, on-demand cross-check. The recorded local first-result payload is 322,816 decoded bytes, including a 42,262-byte worker; the 605 ms observation is a loopback measurement, not a visitor latency promise.

Adds twelve interactive lessons with default/challenge inputs, worked answers and reproducible exports, plus two 50 MW CLI/browser presets. README, tutorials and quickstart lead with the result; material assumptions remain in later sections and exports. Python continuity now has named phases and the package has no lines over 110 characters. Contribution guidance and the roadmap offer concrete newcomer and user-facing work.

Validation: 107 Python tests (106 passed, one Windows symlink skip); seven JavaScript differential test groups; ten browser journeys including all 24 lesson exercises against native Python, seven presets, optional Pyodide equality, corruption/retry, mismatch/cancellation and phone/no-JavaScript paths. Installed-wheel checks include both AI presets, CLI, reports and sensitivity. The seven local-dashboard journeys passed, with the three responsive journeys rerun after restoring the existing local navigation label. Prior JSON/Markdown/HTML artifacts remained byte-identical through the readability refactor.

GitHub Pages deployment follows the existing successful-checks workflow. This is a source/site update; existing alpha tags and downloadable release assets remain intact. AI-scale inputs describe aggregate electrical demand, and the PUE lesson uses the separate planning model. No private source material or control history is included.
