### PR TITLE
docs: add printable battery ride-through worksheet

### DIFF
--- a/docs/tutorials/battery-ride-through-worksheet.md
+++ b/docs/tutorials/battery-ride-through-worksheet.md
@@ -1,0 +1,110 @@
+# Worksheet: calculate battery ride-through
+
+**Lesson 3 | Prediction and exercise**
+
+Name: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_  Date: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+Open [Calculate battery ride-through](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=ride-through).
+Make your prediction before reading the answer. In print preview, check that
+**Worked answer** starts on a separate page; page-break support varies by renderer.
+
+## The situation
+
+This synthetic, uncalibrated lesson has a constant **1,000 kW IT demand**.
+Utility supply fails at **300 s elapsed**, and the generator cannot start.
+The battery supplies the load until its stored energy is depleted.
+
+- Compare **100 kWh** and **50 kWh** of initial stored battery energy.
+- **Charging is disabled**, including before the outage.
+- Battery discharge efficiency is **0.90**; distribution efficiency is **0.95**.
+- Keep the demand, efficiencies, and outage timing unchanged between cases.
+
+**Ride-through duration** is time supported *after the outage*.
+**Elapsed depletion time** is measured from the start of the lesson, at 0 s.
+
+## Predict before calculating
+
+If you halve the stored energy, what happens to the ride-through duration?
+Will the elapsed depletion time also halve? Explain in your own words.
+
+\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+## Calculate, then try it
+
+Use `delivered energy = stored energy × 0.90 × 0.95`, then
+`duration (s) = delivered energy (kWh) / demand (kW) × 3,600 s/h`.
+Add the outage start time to find elapsed depletion time.
+
+| Initial stored energy | Delivered to IT (kWh) | Ride-through (s after outage) | Depletion (s elapsed) |
+| --- | --- | --- | --- |
+| 100 kWh | \_\_\_\_\_\_\_\_\_\_ | \_\_\_\_\_\_\_\_\_\_ | \_\_\_\_\_\_\_\_\_\_ |
+| 50 kWh | \_\_\_\_\_\_\_\_\_\_ | \_\_\_\_\_\_\_\_\_\_ | \_\_\_\_\_\_\_\_\_\_ |
+
+1. Leave **Initial battery (kWh)** at 100 and select **Run lesson**.
+2. Select **Try the challenge value**, then **Run lesson** again for 50 kWh.
+3. Record the browser's **s elapsed** results above. Subtract 300 s to compare
+   them with your predicted ride-through durations.
+4. Select **Show worked answer** only after recording your prediction.
+
+What did your prediction get right, or what would you change?
+
+\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+<div style="break-before: page; page-break-before: always;"></div>
+
+# Worked answer: battery ride-through
+
+**Lesson 3 | Keep separate from the exercise when printing**
+
+These answers use the same synthetic assumptions: constant 1,000 kW IT demand,
+outage at 300 s elapsed, failed generator, **no charging**, and efficiencies of
+0.90 for discharge and 0.95 for distribution.
+
+## 100 kWh case
+
+```text
+Delivered IT energy = 100 kWh × 0.90 × 0.95 = 85.5 kWh
+Ride-through        = 85.5 kWh / 1,000 kW × 3,600 s/h = 307.8 s
+Elapsed depletion   = 300 s + 307.8 s = 607.8 s
+```
+
+## 50 kWh case
+
+```text
+Delivered IT energy = 50 kWh × 0.90 × 0.95 = 42.75 kWh
+Ride-through        = 42.75 kWh / 1,000 kW × 3,600 s/h = 153.9 s
+Elapsed depletion   = 300 s + 153.9 s = 453.9 s
+```
+
+Halving stored energy **halves ride-through duration** because demand and
+efficiencies stay fixed: `153.9 / 307.8 = 0.5`.
+It does **not** halve elapsed depletion time: both cases include the same
+300 seconds before the outage. The browser displays **607.8 s elapsed** and
+**453.9 s elapsed**, not the durations after the outage.
+
+## Compare and explain
+
+If your answer differs, check whether you multiplied both efficiencies,
+converted hours to seconds, and added 300 s only for elapsed depletion time.
+Do not substitute a charging-enabled scenario: adding energy before the outage
+changes the 50 kWh result.
+
+In your own words, why is the outage start time added only to one of the two
+time quantities?
+
+\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+This is a teaching calculation, not equipment sizing or a facility safety,
+reliability, or performance assessment. It does not model battery aging,
+temperature effects, or electrical switching transients.
+
+Return to the [course notes](power-systems-course.md) or
+[run lesson 3 again](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=ride-through).

--- a/docs/tutorials/power-systems-course.md
+++ b/docs/tutorials/power-systems-course.md
@@ -36,6 +36,9 @@ The browser course needs no installation or account. The default calculation use
 
 ## Lesson map
 
+For lesson 3, use the [printable battery ride-through worksheet](battery-ride-through-worksheet.md)
+to write a prediction before checking the worked answer on a separate page.
+
 | # | Lesson and link | Question | Default → challenge | Expected check |
 | ---: | --- | --- | --- | --- |
 | 1 | [Power becomes energy](https://mohammadrezwankhan.github.io/datacenter-twin-lab/?lesson=power-energy) | How much energy does a constant load request in half an hour? | 1,000 → 500 kW | `1,000 × 0.5 = 500 kWh`; the challenge gives 250 kWh. |


### PR DESCRIPTION
## User-visible result

Add a printable lesson-3 worksheet with space for a prediction, the 100/50 kWh exercise, and a worked answer on a separate page. Link it from the course notes. Learners explicitly distinguish duration after the outage from elapsed depletion time.

Fixes #9.

## Scope and evidence

- [x] Kept the existing model and schema boundaries unchanged; documentation only.
- [x] Stated units and assumptions, including no charging, 1,000 kW demand, outage at 300 s, and both efficiencies.
- [x] Checked the existing calculations independently with decimal arithmetic: 307.8/153.9 s ride-through and 607.8/453.9 s elapsed depletion. No new numerical behavior.
- [x] Preserved synthetic/uncalibrated wording and excluded equipment-sizing or physical-safety claims.
- [x] Preserved source provenance and third-party notices.

## Checks run

- `python -m unittest discover -s tests -v` (Python 3.14): 107 tests discovered, 97 passed, 10 skipped because optional API/test-API extras are absent.
- `npm --prefix apps/web run build` (Node 24.19.0): TypeScript and Vite build pass.
- Checked relative link targets in both changed Markdown files; code fences balanced; no Mermaid changes. Opened the live lesson in Chromium and used **Run lesson**, **Try the challenge value**, and **Show worked answer**. The browser returned 607.8 and 453.9 s elapsed, with zero energy-balance residual.
- Rendered the Markdown with tables/fenced-code support, printed through Chromium on A4 and Letter (14 mm margins, 10.5 pt body text), and visually inspected both pages of each output. The answer starts on page 2 and writing lines remain readable.

## Review notes

Only `docs/tutorials/battery-ride-through-worksheet.md` and its course-note link are included. Generated HTML/PDF previews stay outside the repository. Pagination depends on the Markdown renderer; the worksheet asks readers to check print preview because some renderers strip HTML page-break styling. No physical-printer check or learner study is claimed.

AI assistance: OpenAI Codex drafted the worksheet from the existing lesson, checked the live browser route and arithmetic, ran the project checks, and inspected the print previews.
